### PR TITLE
Fix undefined reference to `Adafruit_EPD::fastSPIwrite for ARM with newer gcc

### DIFF
--- a/Adafruit_EPD.cpp
+++ b/Adafruit_EPD.cpp
@@ -272,9 +272,6 @@ void Adafruit_EPD::EPD_data(const uint8_t *buf, uint16_t len)
     @returns the data byte read
 */
 /**************************************************************************/
-#if !defined(__arm__) || (defined(__GNUC__) && __GNUC__ < 5)
-inline // causes "undefined reference" for other cpp files with ARM gcc 5.4
-#endif
 uint8_t Adafruit_EPD::fastSPIwrite(uint8_t d) {
   if (hwSPI) {
     if (singleByteTxns){

--- a/Adafruit_EPD.cpp
+++ b/Adafruit_EPD.cpp
@@ -272,7 +272,10 @@ void Adafruit_EPD::EPD_data(const uint8_t *buf, uint16_t len)
     @returns the data byte read
 */
 /**************************************************************************/
-inline uint8_t Adafruit_EPD::fastSPIwrite(uint8_t d) {
+#if !defined(__arm__) || (defined(__GNUC__) && __GNUC__ < 5)
+inline // causes "undefined reference" for other cpp files with ARM gcc 5.4
+#endif
+uint8_t Adafruit_EPD::fastSPIwrite(uint8_t d) {
   if (hwSPI) {
     if (singleByteTxns){
       uint8_t b;


### PR DESCRIPTION
This tiny patch fixes a compile error on Teensy 3.x, and probably other ARM boards when they update to gcc version 5.4 or later.  Currently most of the Arduino world is still using gcc version 4.8.

I put ifdef checks, so the code remains exactly the same for all non-ARM, and all ARM boards using gcc 4.

Here's the forum thread where the problem was reported.
https://forum.pjrc.com/threads/53412-Adafruit-1-54-quot-Tri-Color-eInk-with-Teensy


Here's a photo from the user who confirmed the fix works.  :)

![thanks](https://user-images.githubusercontent.com/965463/43994516-2dfc73be-9d53-11e8-8b0c-d7ddecc543ce.jpeg)
