### PR TITLE
Fix monochrome display object name

### DIFF
--- a/examples/FeatherWingTest/FeatherWingTest.ino
+++ b/examples/FeatherWingTest/FeatherWingTest.ino
@@ -54,7 +54,7 @@
 /* Uncomment the following line if you are using 2.13" tricolor EPD */
 Adafruit_IL0373 epd(212, 104 ,EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 /* Uncomment the following line if you are using 2.13" monochrome 250*122 EPD */
-//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1675 epd(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 
 bool drawBitmap = false;


### PR DESCRIPTION
This fixes an error if the monochrome EPD object is used, it should match the same object name as the tricolor EPD object name.