### PR TITLE
Allow use of EPD displays on secondary SPI

### DIFF
--- a/Adafruit_EPD.h
+++ b/Adafruit_EPD.h
@@ -88,7 +88,7 @@ public:
                int8_t RST, int8_t CS, int8_t SRCS, int8_t MISO,
                int8_t BUSY = -1);
   Adafruit_EPD(int width, int height, int8_t DC, int8_t RST, int8_t CS,
-               int8_t SRCS, int8_t BUSY = -1);
+               int8_t SRCS, int8_t BUSY = -1, SPIClass *spi = &SPI);
   ~Adafruit_EPD();
 
   void begin(bool reset = true);
@@ -148,6 +148,7 @@ protected:
       _reset_pin,               ///< reset pin
       _cs_pin,                  ///< chip select pin
       _busy_pin;                ///< busy pin
+  SPIClass *_spi = NULL; ///< SPI object
   static bool _isInTransaction; ///< true if SPI bus is in trasnfer state
   bool singleByteTxns;   ///< if true CS will go high after every data byte
                          ///< transferred

--- a/Adafruit_EPD.h
+++ b/Adafruit_EPD.h
@@ -148,7 +148,7 @@ protected:
       _reset_pin,               ///< reset pin
       _cs_pin,                  ///< chip select pin
       _busy_pin;                ///< busy pin
-  SPIClass *_spi = NULL; ///< SPI object
+  SPIClass *_spi = NULL;        ///< SPI object
   static bool _isInTransaction; ///< true if SPI bus is in trasnfer state
   bool singleByteTxns;   ///< if true CS will go high after every data byte
                          ///< transferred

--- a/Adafruit_MCPSRAM.cpp
+++ b/Adafruit_MCPSRAM.cpp
@@ -26,10 +26,12 @@ Adafruit_MCPSRAM::Adafruit_MCPSRAM(int8_t mosi, int8_t miso, int8_t sck,
 /*!
     @brief  Class constructor when using hardware SPI
                 @param cs chip select pin
+                @param spi the SPI bus to use
 */
 /**************************************************************************/
-Adafruit_MCPSRAM::Adafruit_MCPSRAM(int8_t cs) {
+Adafruit_MCPSRAM::Adafruit_MCPSRAM(int8_t cs, SPIClass *spi) {
   _cs = cs;
+  _spi = spi;
   hwSPI = true;
 }
 
@@ -60,9 +62,9 @@ void Adafruit_MCPSRAM::begin() {
 #endif
   }
   if (hwSPI) {
-    SPI.begin();
+    _spi->begin();
 #ifndef SPI_HAS_TRANSACTION
-    SPI.setClockDivider(4);
+    _spi->setClockDivider(4);
 #endif
   }
 
@@ -70,7 +72,7 @@ void Adafruit_MCPSRAM::begin() {
 
   for (int i = 0; i < 3; i++) {
     if (hwSPI) {
-      (void)SPI.transfer(0xFF);
+      (void)_spi->transfer(0xFF);
     } else {
       for (uint8_t bit = 0x80; bit; bit >>= 1) {
 #ifdef HAVE_PORTREG
@@ -119,7 +121,7 @@ void Adafruit_MCPSRAM::write(uint16_t addr, uint8_t *buf, uint16_t num,
     uint8_t d = cmdbuf[i];
 
     if (hwSPI) {
-      (void)SPI.transfer(d);
+      (void)_spi->transfer(d);
     } else {
       for (uint8_t bit = 0x80; bit; bit >>= 1) {
 #ifdef HAVE_PORTREG
@@ -149,7 +151,7 @@ void Adafruit_MCPSRAM::write(uint16_t addr, uint8_t *buf, uint16_t num,
     uint8_t d = buf[i];
 
     if (hwSPI) {
-      (void)SPI.transfer(d);
+      (void)_spi->transfer(d);
     } else {
       for (uint8_t bit = 0x80; bit; bit >>= 1) {
 #ifdef HAVE_PORTREG
@@ -197,7 +199,7 @@ void Adafruit_MCPSRAM::read(uint16_t addr, uint8_t *buf, uint16_t num,
     uint8_t d = cmdbuf[i];
 
     if (hwSPI) {
-      (void)SPI.transfer(d);
+      (void)_spi->transfer(d);
     } else {
       for (uint8_t bit = 0x80; bit; bit >>= 1) {
 #ifdef HAVE_PORTREG
@@ -225,7 +227,7 @@ void Adafruit_MCPSRAM::read(uint16_t addr, uint8_t *buf, uint16_t num,
   for (int i = 0; i < num; i++) {
 
     if (hwSPI) {
-      buf[i] = SPI.transfer(0x00);
+      buf[i] = _spi->transfer(0x00);
     } else {
       for (uint8_t bit = 0x80; bit; bit >>= 1) {
 #ifdef HAVE_PORTREG
@@ -320,7 +322,7 @@ void Adafruit_MCPSRAM::erase(uint16_t addr, uint16_t length, uint8_t val) {
     uint8_t d = cmdbuf[i];
 
     if (hwSPI) {
-      (void)SPI.transfer(d);
+      (void)_spi->transfer(d);
     } else {
       for (uint8_t bit = 0x80; bit; bit >>= 1) {
 #ifdef HAVE_PORTREG
@@ -348,7 +350,7 @@ void Adafruit_MCPSRAM::erase(uint16_t addr, uint16_t length, uint8_t val) {
     uint8_t d = val;
 
     if (hwSPI) {
-      (void)SPI.transfer(d);
+      (void)_spi->transfer(d);
     } else {
       for (uint8_t bit = 0x80; bit; bit >>= 1) {
 #ifdef HAVE_PORTREG
@@ -380,7 +382,7 @@ void Adafruit_MCPSRAM::erase(uint16_t addr, uint16_t length, uint8_t val) {
 /**************************************************************************/
 void Adafruit_MCPSRAM::csHigh() {
 #ifdef SPI_HAS_TRANSACTION
-  SPI.endTransaction();
+  _spi->endTransaction();
 #endif
 #ifdef HAVE_PORTREG
   *csport |= cspinmask;
@@ -396,7 +398,7 @@ void Adafruit_MCPSRAM::csHigh() {
 /**************************************************************************/
 void Adafruit_MCPSRAM::csLow() {
 #ifdef SPI_HAS_TRANSACTION
-  SPI.beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE0));
+  _spi->beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE0));
 #endif
 #ifdef HAVE_PORTREG
   *csport &= ~cspinmask;

--- a/Adafruit_MCPSRAM.h
+++ b/Adafruit_MCPSRAM.h
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <SPI.h>
 
 #define MCPSRAM_READ 0x03  ///< read command
 #define MCPSRAM_WRITE 0x02 ///< write command
@@ -15,7 +16,7 @@
 class Adafruit_MCPSRAM {
 public:
   Adafruit_MCPSRAM(int8_t mosi, int8_t miso, int8_t sck, int8_t cs);
-  Adafruit_MCPSRAM(int8_t cs);
+  Adafruit_MCPSRAM(int8_t cs, SPIClass *spi = &SPI);
   ~Adafruit_MCPSRAM() {}
 
   void begin();
@@ -42,4 +43,5 @@ private:
   PortMask mosipinmask, clkpinmask, cspinmask, misopinmask;
 #endif
   int8_t _cs, _mosi, _miso, _sck;
+  SPIClass *_spi = NULL;
 };


### PR DESCRIPTION
This pull request adds a SPI parameter to the Adafruit_EPD hardware SPI constructor. It allows an Adafruit_EPD subclass the option of working on a secondary SPI bus. The change should be pretty minimal and backwards-compatible; the initializer defaults to the main SPI, and no code changes are necessary for any of the existing display classes (unless you want them to opt in to this functionality, which may be an edge case for most folks).

This change allows a user of the library to create their own Adafruit_EPD subclass that works on the secondary SPI bus (like I've done [here](https://github.com/joeycastillo/The-Open-Book/blob/master/src/OpenBook_IL0398.h#L86)).