### PR TITLE
Fixes #21

### DIFF
--- a/Adafruit_EPD.cpp
+++ b/Adafruit_EPD.cpp
@@ -285,10 +285,10 @@ void Adafruit_EPD::drawPixel(int16_t x, int16_t y, uint16_t color) {
   if (use_sram) {
     sram.write8(addr, *pBuf);
   }
-  
+ 
   // Need to clear out the other buffer
   uint8_t *pOtherBuf;
-  
+ 
   if (use_sram) {
     addr = ((uint32_t)(WIDTH - 1 - x) * (uint32_t)_HEIGHT + y) / 8;
     if ((color == EPD_RED) || (color == EPD_GRAY)) {
@@ -305,7 +305,7 @@ void Adafruit_EPD::drawPixel(int16_t x, int16_t y, uint16_t color) {
       pOtherBuf = color_buffer + addr;
     }
   }
-  
+ 
   *pOtherBuf |= (1 << (7 - y % 8));
 
   if (use_sram) {

--- a/Adafruit_EPD.cpp
+++ b/Adafruit_EPD.cpp
@@ -285,6 +285,32 @@ void Adafruit_EPD::drawPixel(int16_t x, int16_t y, uint16_t color) {
   if (use_sram) {
     sram.write8(addr, *pBuf);
   }
+  
+  // Need to clear out the other buffer
+  uint8_t *pOtherBuf;
+  
+  if (use_sram) {
+    addr = ((uint32_t)(WIDTH - 1 - x) * (uint32_t)_HEIGHT + y) / 8;
+    if ((color == EPD_RED) || (color == EPD_GRAY)) {
+      addr = blackbuffer_addr + addr;
+    } else {
+      addr = colorbuffer_addr + addr;
+    }
+    c = sram.read8(addr);
+    pOtherBuf = &c;
+  } else {
+    if ((color == EPD_RED) || (color == EPD_GRAY)) {
+      pOtherBuf = black_buffer + addr;
+    } else {
+      pOtherBuf = color_buffer + addr;
+    }
+  }
+  
+  *pOtherBuf |= (1 << (7 - y % 8));
+
+  if (use_sram) {
+    sram.write8(addr, *pOtherBuf);
+  }
 }
 
 /**************************************************************************/

--- a/Adafruit_EPD.cpp
+++ b/Adafruit_EPD.cpp
@@ -273,10 +273,12 @@ void Adafruit_EPD::drawPixel(int16_t x, int16_t y, uint16_t color) {
   }
 
   if (((color == EPD_RED || color == EPD_GRAY) && colorInverted) ||
-      ((color == EPD_BLACK) && blackInverted)) {
+      ((color == EPD_BLACK) && blackInverted) ||
+      ((color == EPD_WHITE) && !blackInverted)) {
     *pBuf &= ~(1 << (7 - y % 8));
   } else if (((color == EPD_RED || color == EPD_GRAY) && !colorInverted) ||
-             ((color == EPD_BLACK) && !blackInverted)) {
+             ((color == EPD_BLACK) && !blackInverted) ||
+             ((color == EPD_WHITE) && blackInverted)) {
     *pBuf |= (1 << (7 - y % 8));
   } else if (color == EPD_INVERSE) {
     *pBuf ^= (1 << (7 - y % 8));

--- a/Adafruit_EPD.cpp
+++ b/Adafruit_EPD.cpp
@@ -285,10 +285,10 @@ void Adafruit_EPD::drawPixel(int16_t x, int16_t y, uint16_t color) {
   if (use_sram) {
     sram.write8(addr, *pBuf);
   }
- 
+
   // Need to clear out the other buffer
   uint8_t *pOtherBuf;
- 
+
   if (use_sram) {
     addr = ((uint32_t)(WIDTH - 1 - x) * (uint32_t)_HEIGHT + y) / 8;
     if ((color == EPD_RED) || (color == EPD_GRAY)) {
@@ -305,7 +305,7 @@ void Adafruit_EPD::drawPixel(int16_t x, int16_t y, uint16_t color) {
       pOtherBuf = color_buffer + addr;
     }
   }
- 
+
   *pOtherBuf |= (1 << (7 - y % 8));
 
   if (use_sram) {


### PR DESCRIPTION
When a pixel is set on one buffer, clear the pixel on the other buffer

This was tested with the CPX and the e-ink Tri-color gizmo. I'm not sure what effect this will have on screens with inverted values.
