### PR TITLE
Change reset pins to 8 as to not require 2 fritzings

### DIFF
--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -13,7 +13,7 @@
 #define EPD_CS      9  // can be any pin, but required!
 #define EPD_BUSY    7  // can set to -1 to not use a pin (will wait a fixed delay)
 #define SRAM_CS     6  // can set to -1 to not use a pin (uses a lot of RAM!)
-#define EPD_RESET   5  // can set to -1 and share with chip Reset (can't deep sleep)
+#define EPD_RESET   8  // can set to -1 and share with chip Reset (can't deep sleep)
 
 //ThinkInk_154_Grayscale4_T8 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 //ThinkInk_213_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/ThinkInk_mono/ThinkInk_mono.ino
+++ b/examples/ThinkInk_mono/ThinkInk_mono.ino
@@ -12,7 +12,7 @@
 #define EPD_CS      9
 #define EPD_DC      10
 #define SRAM_CS     6
-#define EPD_RESET   5 // can set to -1 and share with microcontroller Reset!
+#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
 #define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
 
 //ThinkInk_154_Mono_D67 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/ThinkInk_partial/ThinkInk_partial.ino
+++ b/examples/ThinkInk_partial/ThinkInk_partial.ino
@@ -12,7 +12,7 @@
 #define EPD_CS      9
 #define EPD_DC      10
 #define SRAM_CS     6
-#define EPD_RESET   5 // can set to -1 and share with microcontroller Reset!
+#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
 #define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
 
 //ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/ThinkInk_tricolor/ThinkInk_tricolor.ino
+++ b/examples/ThinkInk_tricolor/ThinkInk_tricolor.ino
@@ -13,7 +13,7 @@
 #define EPD_CS      9  // can be any pin, but required!
 #define EPD_BUSY    7  // can set to -1 to not use a pin (will wait a fixed delay)
 #define SRAM_CS     6  // can set to -1 to not use a pin (uses a lot of RAM!)
-#define EPD_RESET   5  // can set to -1 and share with chip Reset (can't deep sleep)
+#define EPD_RESET   8  // can set to -1 and share with chip Reset (can't deep sleep)
 
 //ThinkInk_154_Tricolor_Z17 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 //ThinkInk_154_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/src/Adafruit_ThinkInk.h
+++ b/src/Adafruit_ThinkInk.h
@@ -4,8 +4,8 @@ typedef enum {
   THINKINK_GRAYSCALE4,
 } thinkinkmode_t;
 
-#include "panels/ThinkInk_154_Tricolor_Z17.h"
 #include "panels/ThinkInk_154_Tricolor_RW.h"
+#include "panels/ThinkInk_154_Tricolor_Z17.h"
 #include "panels/ThinkInk_213_Tricolor_RW.h"
 #include "panels/ThinkInk_213_Tricolor_Z16.h"
 #include "panels/ThinkInk_270_Tricolor_C44.h"


### PR DESCRIPTION
Since SD_CS uses pin 5 on the feather, I realized it made more sense to use pin 8 for the feather since it doesn't actually exist and isn't used, but can be used on a metro with a breakout. So then I can just make a single complete fritzing with all wires attached.