### PR TITLE
Add “ink mode” to ThinkInk classes (needed for ImageReader)

### DIFF
--- a/src/Adafruit_ThinkInk.h
+++ b/src/Adafruit_ThinkInk.h
@@ -1,3 +1,8 @@
+#ifndef _ADAFRUIT_THINKINK_H_
+#define _ADAFRUIT_THINKINK_H_
+
+#include "Adafruit_EPD.h"
+
 typedef enum {
   THINKINK_MONO,
   THINKINK_TRICOLOR,
@@ -22,3 +27,5 @@ typedef enum {
 #include "panels/ThinkInk_213_Mono_B73.h"
 #include "panels/ThinkInk_213_Mono_BN.h"
 #include "panels/ThinkInk_420_Mono_BN.h"
+
+#endif // _ADAFRUIT_THINKINK_H_

--- a/src/panels/ThinkInk_154_Grayscale4_T8.h
+++ b/src/panels/ThinkInk_154_Grayscale4_T8.h
@@ -1,6 +1,8 @@
 #ifndef _THINKINK_154_GRAYSCALE4_T8_H
 #define _THINKINK_154_GRAYSCALE4_T8_H
 
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+
 // clang-format off
 
 static const uint8_t ti_154t8_gray4_init_code[] {
@@ -144,7 +146,6 @@ static const uint8_t ti_154t8_gray4_lut_code[] = {
 // clang-format on
 
 class ThinkInk_154_Grayscale4_T8 : public Adafruit_IL0373 {
-private:
 public:
   ThinkInk_154_Grayscale4_T8(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                              int8_t CS, int8_t SRCS, int8_t MISO,
@@ -160,6 +161,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(1, true); // layer 1 uninverted
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     if (mode == THINKINK_GRAYSCALE4) {
       _epd_init_code = ti_154t8_gray4_init_code;
       _epd_lut_code = ti_154t8_gray4_lut_code;
@@ -170,8 +173,7 @@ public:
       layer_colors[EPD_GRAY] = 0b10;
       layer_colors[EPD_LIGHT] = 0b01;
       layer_colors[EPD_DARK] = 0b10;
-    }
-    if (mode == THINKINK_MONO) {
+    } else if (mode == THINKINK_MONO) {
       _epd_init_code = ti_154t8_monofull_init_code;
       _epd_partial_init_code = ti_154t8_monopart_init_code;
       _epd_partial_lut_code = ti_154t8_monopart_lut_code;
@@ -187,7 +189,12 @@ public:
     default_refresh_delay = 1000;
     setRotation(3);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_154_GRAYSCALE4_T8_H

--- a/src/panels/ThinkInk_154_Grayscale4_T8.h
+++ b/src/panels/ThinkInk_154_Grayscale4_T8.h
@@ -1,41 +1,42 @@
 #ifndef _THINKINK_154_GRAYSCALE4_T8_H
 #define _THINKINK_154_GRAYSCALE4_T8_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 // clang-format off
 
 static const uint8_t ti_154t8_gray4_init_code[] {
   IL0373_POWER_SETTING, 5, 0x03, 0x00, 0x2b, 0x2b, 0x13,
-    IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
-    IL0373_POWER_ON, 0,
-    0xFF, 200,
-    IL0373_PANEL_SETTING, 1, 0x3F,
-    IL0373_PLL, 1, 0x3C,    
-    IL0373_VCM_DC_SETTING, 1, 0x12,
-    IL0373_CDI, 1, 0x97,
-    0xFE // EOM
+  IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
+  IL0373_POWER_ON, 0,
+  0xFF, 200,
+  IL0373_PANEL_SETTING, 1, 0x3F,
+  IL0373_PLL, 1, 0x3C,    
+  IL0373_VCM_DC_SETTING, 1, 0x12,
+  IL0373_CDI, 1, 0x97,
+  0xFE // EOM
 };
 
 static const uint8_t ti_154t8_monopart_init_code[] {
   IL0373_POWER_SETTING, 5, 0x03, 0x00, 0x2b, 0x2b, 0x03,
-    IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
-    IL0373_POWER_ON, 0,
-    0xFF, 200,
-    IL0373_PANEL_SETTING, 2, 0xbF, 0x0d,
-    IL0373_PLL, 1, 0x3C,    
-    IL0373_VCM_DC_SETTING, 1, 0x12,
-    IL0373_CDI, 1, 0x47,
-    0xFE // EOM
+  IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
+  IL0373_POWER_ON, 0,
+  0xFF, 200,
+  IL0373_PANEL_SETTING, 2, 0xbF, 0x0d,
+  IL0373_PLL, 1, 0x3C,    
+  IL0373_VCM_DC_SETTING, 1, 0x12,
+  IL0373_CDI, 1, 0x47,
+  0xFE // EOM
 };
 
 static const uint8_t ti_154t8_monofull_init_code[] {
-    IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
-    IL0373_POWER_ON, 0,
-    0xFF, 200,
-    IL0373_PANEL_SETTING, 2, 0x1f, 0x0d,
-    IL0373_CDI, 1, 0x97,
-    0xFE // EOM
+  IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
+  IL0373_POWER_ON, 0,
+  0xFF, 200,
+  IL0373_PANEL_SETTING, 2, 0x1f, 0x0d,
+  IL0373_CDI, 1, 0x97,
+  0xFE // EOM
 };
 
 static const uint8_t ti_154t8_monopart_lut_code[] = {

--- a/src/panels/ThinkInk_154_Mono_D27.h
+++ b/src/panels/ThinkInk_154_Mono_D27.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_154_MONO_D27_H
 #define _THINKINK_154_MONO_D27_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_154_Mono_D27 : public Adafruit_SSD1608 {
-private:
 public:
   ThinkInk_154_Mono_D27(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                         int8_t CS, int8_t SRCS, int8_t MISO, int8_t BUSY = -1)
@@ -19,6 +18,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(0, true); // only one buffer
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b01;
     layer_colors[EPD_RED] = 0b01;
@@ -29,7 +30,12 @@ public:
     default_refresh_delay = 1000;
     setRotation(3);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_154_MONO_D27_H

--- a/src/panels/ThinkInk_154_Mono_D27.h
+++ b/src/panels/ThinkInk_154_Mono_D27.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_154_MONO_D27_H
 #define _THINKINK_154_MONO_D27_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_154_Mono_D27 : public Adafruit_SSD1608 {
 public:

--- a/src/panels/ThinkInk_154_Mono_D67.h
+++ b/src/panels/ThinkInk_154_Mono_D67.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_154_MONO_D67_H
 #define _THINKINK_154_MONO_D67_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_154_Mono_D67 : public Adafruit_SSD1681 {
-private:
 public:
   ThinkInk_154_Mono_D67(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                         int8_t CS, int8_t SRCS, int8_t MISO, int8_t BUSY = -1)
@@ -19,6 +18,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(0, true); // only one buffer
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b01;
     layer_colors[EPD_RED] = 0b01;
@@ -29,7 +30,12 @@ public:
     default_refresh_delay = 1000;
     setRotation(3);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_154_MONO_D67_H

--- a/src/panels/ThinkInk_154_Mono_D67.h
+++ b/src/panels/ThinkInk_154_Mono_D67.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_154_MONO_D67_H
 #define _THINKINK_154_MONO_D67_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_154_Mono_D67 : public Adafruit_SSD1681 {
 public:

--- a/src/panels/ThinkInk_154_Tricolor_RW.h
+++ b/src/panels/ThinkInk_154_Tricolor_RW.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_154_TRICOLOR_RW_H
 #define _THINKINK_154_TRICOLOR_RW_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_154_Tricolor_RW : public Adafruit_SSD1680 {
 public:

--- a/src/panels/ThinkInk_154_Tricolor_RW.h
+++ b/src/panels/ThinkInk_154_Tricolor_RW.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_154_TRICOLOR_RW_H
 #define _THINKINK_154_TRICOLOR_RW_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_154_Tricolor_RW : public Adafruit_SSD1680 {
-private:
 public:
   ThinkInk_154_Tricolor_RW(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                            int8_t CS, int8_t SRCS, int8_t MISO,
@@ -20,6 +19,8 @@ public:
     setBlackBuffer(0, true);
     setColorBuffer(1, false);
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b01;
     layer_colors[EPD_RED] = 0b10;
@@ -30,7 +31,12 @@ public:
     default_refresh_delay = 13000;
     setRotation(3);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_154_TRI

--- a/src/panels/ThinkInk_154_Tricolor_Z17.h
+++ b/src/panels/ThinkInk_154_Tricolor_Z17.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_154_TRICOLOR_Z17_H
 #define _THINKINK_154_TRICOLOR_Z17_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_154_Tricolor_Z17 : public Adafruit_IL0373 {
 public:

--- a/src/panels/ThinkInk_154_Tricolor_Z17.h
+++ b/src/panels/ThinkInk_154_Tricolor_Z17.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_154_TRICOLOR_Z17_H
 #define _THINKINK_154_TRICOLOR_Z17_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_154_Tricolor_Z17 : public Adafruit_IL0373 {
-private:
 public:
   ThinkInk_154_Tricolor_Z17(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                             int8_t CS, int8_t SRCS, int8_t MISO,
@@ -20,6 +19,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(1, true); // layer 1 uninverted
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b10;
     layer_colors[EPD_RED] = 0b01;
@@ -31,7 +32,12 @@ public:
 
     setRotation(3);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_154_TRICOLOR_Z17_H

--- a/src/panels/ThinkInk_213_Grayscale4_T5.h
+++ b/src/panels/ThinkInk_213_Grayscale4_T5.h
@@ -1,7 +1,7 @@
 #ifndef _THINKINK_213_GRAYSCALE4_T5_H
 #define _THINKINK_213_GRAYSCALE4_T5_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 // clang-format off
 
@@ -146,7 +146,6 @@ static const uint8_t ti_213t5_gray4_lut_code[] = {
 // clang-format on
 
 class ThinkInk_213_Grayscale4_T5 : public Adafruit_IL0373 {
-private:
 public:
   ThinkInk_213_Grayscale4_T5(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                              int8_t CS, int8_t SRCS, int8_t MISO,
@@ -162,6 +161,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(1, true); // layer 1 uninverted
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     if (mode == THINKINK_GRAYSCALE4) {
       _epd_init_code = ti_213t5_gray4_init_code;
       _epd_lut_code = ti_213t5_gray4_lut_code;
@@ -172,8 +173,7 @@ public:
       layer_colors[EPD_GRAY] = 0b10;
       layer_colors[EPD_LIGHT] = 0b01;
       layer_colors[EPD_DARK] = 0b10;
-    }
-    if (mode == THINKINK_MONO) {
+    } else if (mode == THINKINK_MONO) {
       _epd_init_code = ti_213t5_monofull_init_code;
       _epd_partial_init_code = ti_213t5_monopart_init_code;
       _epd_partial_lut_code = ti_213t5_monopart_lut_code;
@@ -189,7 +189,12 @@ public:
     default_refresh_delay = 1000;
 
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_213_GRAYSCALE4_T5_H

--- a/src/panels/ThinkInk_213_Grayscale4_T5.h
+++ b/src/panels/ThinkInk_213_Grayscale4_T5.h
@@ -1,41 +1,42 @@
 #ifndef _THINKINK_213_GRAYSCALE4_T5_H
 #define _THINKINK_213_GRAYSCALE4_T5_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 // clang-format off
 
 static const uint8_t ti_213t5_gray4_init_code[] {
   IL0373_POWER_SETTING, 5, 0x03, 0x00, 0x2b, 0x2b, 0x13,
-    IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
-    IL0373_POWER_ON, 0,
-    0xFF, 200,
-    IL0373_PANEL_SETTING, 1, 0x3F,
-    IL0373_PLL, 1, 0x3C,    
-    IL0373_VCM_DC_SETTING, 1, 0x12,
-    IL0373_CDI, 1, 0x97,
-    0xFE // EOM
+  IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
+  IL0373_POWER_ON, 0,
+  0xFF, 200,
+  IL0373_PANEL_SETTING, 1, 0x3F,
+  IL0373_PLL, 1, 0x3C,    
+  IL0373_VCM_DC_SETTING, 1, 0x12,
+  IL0373_CDI, 1, 0x97,
+  0xFE // EOM
 };
 
 static const uint8_t ti_213t5_monopart_init_code[] {
   IL0373_POWER_SETTING, 5, 0x03, 0x00, 0x2b, 0x2b, 0x03,
-    IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
-    IL0373_POWER_ON, 0,
-    0xFF, 200,
-    IL0373_PANEL_SETTING, 2, 0xbF, 0x0d,
-    IL0373_PLL, 1, 0x3C,    
-    IL0373_VCM_DC_SETTING, 1, 0x12,
-    IL0373_CDI, 1, 0x47,
-    0xFE // EOM
+  IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
+  IL0373_POWER_ON, 0,
+  0xFF, 200,
+  IL0373_PANEL_SETTING, 2, 0xbF, 0x0d,
+  IL0373_PLL, 1, 0x3C,    
+  IL0373_VCM_DC_SETTING, 1, 0x12,
+  IL0373_CDI, 1, 0x47,
+  0xFE // EOM
 };
 
 static const uint8_t ti_213t5_monofull_init_code[] {
-    IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
-    IL0373_POWER_ON, 0,
-    0xFF, 200,
-    IL0373_PANEL_SETTING, 2, 0x1f, 0x0d,
-    IL0373_CDI, 1, 0x97,
-    0xFE // EOM
+  IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
+  IL0373_POWER_ON, 0,
+  0xFF, 200,
+  IL0373_PANEL_SETTING, 2, 0x1f, 0x0d,
+  IL0373_CDI, 1, 0x97,
+  0xFE // EOM
 };
 
 static const uint8_t ti_213t5_monopart_lut_code[] = {

--- a/src/panels/ThinkInk_213_Mono_B72.h
+++ b/src/panels/ThinkInk_213_Mono_B72.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_213_MONO_B72_H
 #define _THINKINK_213_MONO_B72_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_213_Mono_B72 : public Adafruit_SSD1675 {
-private:
 public:
   ThinkInk_213_Mono_B72(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                         int8_t CS, int8_t SRCS, int8_t MISO, int8_t BUSY = -1)
@@ -19,6 +18,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(0, true); // only one buffer
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b01;
     layer_colors[EPD_RED] = 0b01;
@@ -29,7 +30,12 @@ public:
     default_refresh_delay = 1000;
     setRotation(0);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_213_MONO_B72_H

--- a/src/panels/ThinkInk_213_Mono_B72.h
+++ b/src/panels/ThinkInk_213_Mono_B72.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_213_MONO_B72_H
 #define _THINKINK_213_MONO_B72_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_213_Mono_B72 : public Adafruit_SSD1675 {
 public:

--- a/src/panels/ThinkInk_213_Mono_B73.h
+++ b/src/panels/ThinkInk_213_Mono_B73.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_213_MONO_B73_H
 #define _THINKINK_213_MONO_B73_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_213_Mono_B73 : public Adafruit_SSD1675B {
-private:
 public:
   ThinkInk_213_Mono_B73(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                         int8_t CS, int8_t SRCS, int8_t MISO, int8_t BUSY = -1)
@@ -19,6 +18,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(0, true); // only one buffer
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b01;
     layer_colors[EPD_RED] = 0b01;
@@ -29,7 +30,12 @@ public:
     default_refresh_delay = 1000;
     setRotation(0);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_213_MONO_B73_H

--- a/src/panels/ThinkInk_213_Mono_B73.h
+++ b/src/panels/ThinkInk_213_Mono_B73.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_213_MONO_B73_H
 #define _THINKINK_213_MONO_B73_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_213_Mono_B73 : public Adafruit_SSD1675B {
 public:

--- a/src/panels/ThinkInk_213_Mono_BN.h
+++ b/src/panels/ThinkInk_213_Mono_BN.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_213_MONO_BN_H
 #define _THINKINK_213_MONO_BN_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_213_Mono_BN : public Adafruit_SSD1680 {
 public:

--- a/src/panels/ThinkInk_213_Mono_BN.h
+++ b/src/panels/ThinkInk_213_Mono_BN.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_213_MONO_BN_H
 #define _THINKINK_213_MONO_BN_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_213_Mono_BN : public Adafruit_SSD1680 {
-private:
 public:
   ThinkInk_213_Mono_BN(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                        int8_t CS, int8_t SRCS, int8_t MISO, int8_t BUSY = -1)
@@ -19,6 +18,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(0, true); // only one buffer
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b01;
     layer_colors[EPD_RED] = 0b01;
@@ -29,7 +30,12 @@ public:
     default_refresh_delay = 1000;
     setRotation(0);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_213_MONO_BN_H

--- a/src/panels/ThinkInk_213_Tricolor_RW.h
+++ b/src/panels/ThinkInk_213_Tricolor_RW.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_213_TRICOLOR_RW_H
 #define _THINKINK_213_TRICOLOR_RW_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_213_Tricolor_RW : public Adafruit_SSD1680 {
 public:

--- a/src/panels/ThinkInk_213_Tricolor_RW.h
+++ b/src/panels/ThinkInk_213_Tricolor_RW.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_213_TRICOLOR_RW_H
 #define _THINKINK_213_TRICOLOR_RW_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_213_Tricolor_RW : public Adafruit_SSD1680 {
-private:
 public:
   ThinkInk_213_Tricolor_RW(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                            int8_t CS, int8_t SRCS, int8_t MISO,
@@ -20,6 +19,8 @@ public:
     setBlackBuffer(0, true);
     setColorBuffer(1, false);
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b01;
     layer_colors[EPD_RED] = 0b10;
@@ -30,7 +31,12 @@ public:
     default_refresh_delay = 13000;
     setRotation(0);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_213_TRI

--- a/src/panels/ThinkInk_213_Tricolor_Z16.h
+++ b/src/panels/ThinkInk_213_Tricolor_Z16.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_213_TRICOLOR_Z16_H
 #define _THINKINK_213_TRICOLOR_Z16_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_213_Tricolor_Z16 : public Adafruit_IL0373 {
-private:
 public:
   ThinkInk_213_Tricolor_Z16(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                             int8_t CS, int8_t SRCS, int8_t MISO,
@@ -20,6 +19,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(1, true); // layer 1 uninverted
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b10;
     layer_colors[EPD_RED] = 0b01;
@@ -30,7 +31,12 @@ public:
     default_refresh_delay = 16000;
 
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_213_TRICOLOR_Z16_H

--- a/src/panels/ThinkInk_213_Tricolor_Z16.h
+++ b/src/panels/ThinkInk_213_Tricolor_Z16.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_213_TRICOLOR_Z16_H
 #define _THINKINK_213_TRICOLOR_Z16_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_213_Tricolor_Z16 : public Adafruit_IL0373 {
 public:

--- a/src/panels/ThinkInk_270_Tricolor_C44.h
+++ b/src/panels/ThinkInk_270_Tricolor_C44.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_270_TRICOLOR_C44_H
 #define _THINKINK_270_TRICOLOR_C44_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_270_Tricolor_C44 : public Adafruit_IL91874 {
 public:

--- a/src/panels/ThinkInk_270_Tricolor_C44.h
+++ b/src/panels/ThinkInk_270_Tricolor_C44.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_270_TRICOLOR_C44_H
 #define _THINKINK_270_TRICOLOR_C44_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_270_Tricolor_C44 : public Adafruit_IL91874 {
-private:
 public:
   ThinkInk_270_Tricolor_C44(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                             int8_t CS, int8_t SRCS, int8_t MISO,
@@ -18,6 +17,8 @@ public:
   void begin(thinkinkmode_t mode = THINKINK_TRICOLOR) {
     Adafruit_IL91874::begin(true);
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b10;
     layer_colors[EPD_BLACK] = 0b01;
     layer_colors[EPD_RED] = 0b10;
@@ -27,7 +28,12 @@ public:
 
     default_refresh_delay = 13000;
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_270_TRICOLOR_C44_H

--- a/src/panels/ThinkInk_290_Grayscale4_T5.h
+++ b/src/panels/ThinkInk_290_Grayscale4_T5.h
@@ -1,41 +1,42 @@
 #ifndef _THINKINK_290_GRAYSCALE4_T5_H
 #define _THINKINK_290_GRAYSCALE4_T5_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 // clang-format off
 
 static const uint8_t ti_290t5_gray4_init_code[] {
   IL0373_POWER_SETTING, 5, 0x03, 0x00, 0x2b, 0x2b, 0x13,
-    IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
-    IL0373_POWER_ON, 0,
-    0xFF, 200,
-    IL0373_PANEL_SETTING, 1, 0x3F,
-    IL0373_PLL, 1, 0x3C,    
-    IL0373_VCM_DC_SETTING, 1, 0x12,
-    IL0373_CDI, 1, 0x97,
-    0xFE // EOM
+  IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
+  IL0373_POWER_ON, 0,
+  0xFF, 200,
+  IL0373_PANEL_SETTING, 1, 0x3F,
+  IL0373_PLL, 1, 0x3C,    
+  IL0373_VCM_DC_SETTING, 1, 0x12,
+  IL0373_CDI, 1, 0x97,
+  0xFE // EOM
 };
 
 static const uint8_t ti_290t5_monopart_init_code[] {
   IL0373_POWER_SETTING, 5, 0x03, 0x00, 0x2b, 0x2b, 0x03,
-    IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
-    IL0373_POWER_ON, 0,
-    0xFF, 200,
-    IL0373_PANEL_SETTING, 2, 0xbF, 0x0d,
-    IL0373_PLL, 1, 0x3C,    
-    IL0373_VCM_DC_SETTING, 1, 0x12,
-    IL0373_CDI, 1, 0x47,
-    0xFE // EOM
+  IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
+  IL0373_POWER_ON, 0,
+  0xFF, 200,
+  IL0373_PANEL_SETTING, 2, 0xbF, 0x0d,
+  IL0373_PLL, 1, 0x3C,    
+  IL0373_VCM_DC_SETTING, 1, 0x12,
+  IL0373_CDI, 1, 0x47,
+  0xFE // EOM
 };
 
 static const uint8_t ti_290t5_monofull_init_code[] {
-    IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
-    IL0373_POWER_ON, 0,
-    0xFF, 200,
-    IL0373_PANEL_SETTING, 2, 0x1f, 0x0d,
-    IL0373_CDI, 1, 0x97,
-    0xFE // EOM
+  IL0373_BOOSTER_SOFT_START, 3, 0x17, 0x17, 0x17,
+  IL0373_POWER_ON, 0,
+  0xFF, 200,
+  IL0373_PANEL_SETTING, 2, 0x1f, 0x0d,
+  IL0373_CDI, 1, 0x97,
+  0xFE // EOM
 };
 
 static const uint8_t ti_290t5_monopart_lut_code[] = {

--- a/src/panels/ThinkInk_290_Grayscale4_T5.h
+++ b/src/panels/ThinkInk_290_Grayscale4_T5.h
@@ -1,7 +1,7 @@
 #ifndef _THINKINK_290_GRAYSCALE4_T5_H
 #define _THINKINK_290_GRAYSCALE4_T5_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 // clang-format off
 
@@ -146,7 +146,6 @@ const uint8_t ti_290t5_gray4_lut_code[] = {
 // clang-format on
 
 class ThinkInk_290_Grayscale4_T5 : public Adafruit_IL0373 {
-private:
 public:
   ThinkInk_290_Grayscale4_T5(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                              int8_t CS, int8_t SRCS, int8_t MISO,
@@ -162,6 +161,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(1, true); // layer 1 uninverted
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     if (mode == THINKINK_GRAYSCALE4) {
       _epd_init_code = ti_290t5_gray4_init_code;
       _epd_lut_code = ti_290t5_gray4_lut_code;
@@ -172,8 +173,7 @@ public:
       layer_colors[EPD_GRAY] = 0b10;
       layer_colors[EPD_LIGHT] = 0b01;
       layer_colors[EPD_DARK] = 0b10;
-    }
-    if (mode == THINKINK_MONO) {
+    } else if (mode == THINKINK_MONO) {
       _epd_init_code = ti_290t5_monofull_init_code;
       _epd_partial_init_code = ti_290t5_monopart_init_code;
       _epd_partial_lut_code = ti_290t5_monopart_lut_code;
@@ -189,7 +189,12 @@ public:
     default_refresh_delay = 800;
 
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_290_GRAYSCALE4_T5_H

--- a/src/panels/ThinkInk_290_Tricolor_Z10.h
+++ b/src/panels/ThinkInk_290_Tricolor_Z10.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_290_TRICOLOR_Z10_H
 #define _THINKINK_290_TRICOLOR_Z10_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_290_Tricolor_Z10 : public Adafruit_IL0373 {
 public:

--- a/src/panels/ThinkInk_290_Tricolor_Z10.h
+++ b/src/panels/ThinkInk_290_Tricolor_Z10.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_290_TRICOLOR_Z10_H
 #define _THINKINK_290_TRICOLOR_Z10_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_290_Tricolor_Z10 : public Adafruit_IL0373 {
-private:
 public:
   ThinkInk_290_Tricolor_Z10(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                             int8_t CS, int8_t SRCS, int8_t MISO,
@@ -20,6 +19,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(1, true); // layer 1 uninverted
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b10;
     layer_colors[EPD_RED] = 0b01;
@@ -30,7 +31,12 @@ public:
     default_refresh_delay = 13000;
 
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_290_TRICOLOR_H

--- a/src/panels/ThinkInk_420_Mono_BN.h
+++ b/src/panels/ThinkInk_420_Mono_BN.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_420_MONO_BN_H
 #define _THINKINK_420_MONO_BN_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_420_Mono_BN : public Adafruit_SSD1619 {
 public:

--- a/src/panels/ThinkInk_420_Mono_BN.h
+++ b/src/panels/ThinkInk_420_Mono_BN.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_420_MONO_BN_H
 #define _THINKINK_420_MONO_BN_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_420_Mono_BN : public Adafruit_SSD1619 {
-private:
 public:
   ThinkInk_420_Mono_BN(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                        int8_t CS, int8_t SRCS, int8_t MISO, int8_t BUSY = -1)
@@ -19,6 +18,8 @@ public:
     setColorBuffer(0, true); // layer 0 uninverted
     setBlackBuffer(0, true); // only one buffer
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b01;
     layer_colors[EPD_RED] = 0b01;
@@ -29,7 +30,12 @@ public:
     default_refresh_delay = 1000;
     setRotation(1);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_420_MONO_BN_H

--- a/src/panels/ThinkInk_420_Tricolor_RW.h
+++ b/src/panels/ThinkInk_420_Tricolor_RW.h
@@ -1,10 +1,9 @@
 #ifndef _THINKINK_420_TRICOLOR_RW_H
 #define _THINKINK_420_TRICOLOR_RW_H
 
-#include "Adafruit_EPD.h"
+#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
 
 class ThinkInk_420_Tricolor_RW : public Adafruit_SSD1619 {
-private:
 public:
   ThinkInk_420_Tricolor_RW(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                            int8_t CS, int8_t SRCS, int8_t MISO,
@@ -20,6 +19,8 @@ public:
     setBlackBuffer(0, true);
     setColorBuffer(1, false);
 
+    inkmode = mode; // Preserve ink mode for ImageReader or others
+
     layer_colors[EPD_WHITE] = 0b00;
     layer_colors[EPD_BLACK] = 0b01;
     layer_colors[EPD_RED] = 0b10;
@@ -30,7 +31,12 @@ public:
     default_refresh_delay = 13000;
     setRotation(1);
     powerDown();
-  };
+  }
+
+  thinkinkmode_t getMode(void) { return inkmode; }
+
+private:
+  thinkinkmode_t inkmode; // Ink mode passed to begin()
 };
 
 #endif // _THINKINK_420_TRI

--- a/src/panels/ThinkInk_420_Tricolor_RW.h
+++ b/src/panels/ThinkInk_420_Tricolor_RW.h
@@ -1,7 +1,8 @@
 #ifndef _THINKINK_420_TRICOLOR_RW_H
 #define _THINKINK_420_TRICOLOR_RW_H
 
-#include "Adafruit_ThinkInk.h" // Includes EPD header, ink mode enum
+// This file is #included by Adafruit_ThinkInk.h and does not need to
+// #include anything else to pick up the EPD header or ink mode enum.
 
 class ThinkInk_420_Tricolor_RW : public Adafruit_SSD1619 {
 public:


### PR DESCRIPTION
Please review carefully before merging, in case this is Not The Right Way To Go About Things.

All of the ThinkInk classes (in panels directory) are updated to preserve the “ink mode” that was passed to their begin() function, with a corresponding function to query this later. This was done primarily for ImageReader (but maybe others can benefit), so it can do the Right Thing depending on the display configuration…but without having to state this in two different places in a sketch (once when calling the display’s begin() func, another when loading an image, which is just A Recipe For Disaster that these two would get out of sync…now instead the setting from the former can be queried to pass to the latter…it’s a roundabout extra step, but is at least always consistent).

No changes have been made to the core Adafruit_EPD class itself, nor the drivers, only the ThinkInk classes. Some minor table formatting for consistency because you know I’m Just That Way.

Version number in properties file is NOT bumped yet, until this is PR is reviewed.