### PR TITLE
Change some local vars to be more explicit

### DIFF
--- a/src/Adafruit_EPD.cpp
+++ b/src/Adafruit_EPD.cpp
@@ -493,9 +493,9 @@ void Adafruit_EPD::EPD_commandList(const uint8_t *init_code) {
   uint8_t buf[64];
 
   while (init_code[0] != 0xFE) {
-    char cmd = init_code[0];
+    uint8_t cmd = init_code[0];
     init_code++;
-    int num_args = init_code[0];
+    uint8_t num_args = init_code[0];
     init_code++;
     if (cmd == 0xFF) {
       busy_wait();


### PR DESCRIPTION
Fixes #32 

The implicit casting was causing grief on AVR.

Tested on Metro Mini and Itsy Bitsy M4 (to prove it didn't break ARM) using EPDTest.ino.

Here's the Metro Mini setup:
![metro_mini_epd](https://user-images.githubusercontent.com/8755041/99468847-69fa2880-28f6-11eb-9619-85b9b0ad8500.jpg)
