### PR TITLE
fix device blocking on ESP32 if hardware SPI is used

### DIFF
--- a/src/Adafruit_EPD.cpp
+++ b/src/Adafruit_EPD.cpp
@@ -647,10 +647,10 @@ void Adafruit_EPD::csHigh() {
   digitalWrite(_cs_pin, HIGH);
 #endif
 
-    if ( _isInTransaction ) {
-        spi_dev->endTransaction();
-        _isInTransaction = false;
-    }
+  if ( _isInTransaction ) {
+    spi_dev->endTransaction();
+    _isInTransaction = false;
+  }
 }
 
 /**************************************************************************/
@@ -659,10 +659,10 @@ void Adafruit_EPD::csHigh() {
 */
 /**************************************************************************/
 void Adafruit_EPD::csLow() {
-    if ( ! _isInTransaction ) {
-        spi_dev->beginTransaction();
-        _isInTransaction = true;
-    }
+  if ( ! _isInTransaction ) {
+    spi_dev->beginTransaction();
+    _isInTransaction = true;
+  }
 
 #ifdef BUSIO_USE_FAST_PINIO
   *csPort &= ~csPinMask;

--- a/src/Adafruit_EPD.cpp
+++ b/src/Adafruit_EPD.cpp
@@ -304,6 +304,7 @@ void Adafruit_EPD::display(bool sleep) {
 
   if (use_sram) {
     sram.csLow();
+    _isInTransaction = true;
     // send read command
     SPItransfer(MCPSRAM_READ);
     // send address
@@ -322,6 +323,7 @@ void Adafruit_EPD::display(bool sleep) {
     }
     csHigh();
     sram.csHigh();
+    _isInTransaction = false;
   } else {
     // write image
     writeRAMCommand(0);
@@ -345,6 +347,7 @@ void Adafruit_EPD::display(bool sleep) {
 
   if (use_sram) {
     sram.csLow();
+    _isInTransaction = true;
     // send read command
     SPItransfer(MCPSRAM_READ);
     // send address
@@ -361,6 +364,7 @@ void Adafruit_EPD::display(bool sleep) {
     }
     csHigh();
     sram.csHigh();
+    _isInTransaction = false;
   } else {
     writeRAMCommand(1);
     dcHigh();
@@ -643,8 +647,10 @@ void Adafruit_EPD::csHigh() {
   digitalWrite(_cs_pin, HIGH);
 #endif
 
-  spi_dev->endTransaction();
-  _isInTransaction = false;
+	if ( _isInTransaction ) {
+	  spi_dev->endTransaction();
+	  _isInTransaction = false;
+	}
 }
 
 /**************************************************************************/
@@ -653,8 +659,10 @@ void Adafruit_EPD::csHigh() {
 */
 /**************************************************************************/
 void Adafruit_EPD::csLow() {
-  spi_dev->beginTransaction();
-  _isInTransaction = true;
+	if ( ! _isInTransaction ) {
+	  spi_dev->beginTransaction();
+	  _isInTransaction = true;
+	}
 
 #ifdef BUSIO_USE_FAST_PINIO
   *csPort &= ~csPinMask;

--- a/src/Adafruit_EPD.cpp
+++ b/src/Adafruit_EPD.cpp
@@ -659,7 +659,7 @@ void Adafruit_EPD::csHigh() {
 */
 /**************************************************************************/
 void Adafruit_EPD::csLow() {
-  if (! _isInTransaction) {
+  if (!_isInTransaction) {
     spi_dev->beginTransaction();
     _isInTransaction = true;
   }

--- a/src/Adafruit_EPD.cpp
+++ b/src/Adafruit_EPD.cpp
@@ -647,10 +647,10 @@ void Adafruit_EPD::csHigh() {
   digitalWrite(_cs_pin, HIGH);
 #endif
 
-	if ( _isInTransaction ) {
-	  spi_dev->endTransaction();
-	  _isInTransaction = false;
-	}
+    if ( _isInTransaction ) {
+        spi_dev->endTransaction();
+        _isInTransaction = false;
+    }
 }
 
 /**************************************************************************/
@@ -659,10 +659,10 @@ void Adafruit_EPD::csHigh() {
 */
 /**************************************************************************/
 void Adafruit_EPD::csLow() {
-	if ( ! _isInTransaction ) {
-	  spi_dev->beginTransaction();
-	  _isInTransaction = true;
-	}
+    if ( ! _isInTransaction ) {
+        spi_dev->beginTransaction();
+        _isInTransaction = true;
+    }
 
 #ifdef BUSIO_USE_FAST_PINIO
   *csPort &= ~csPinMask;

--- a/src/Adafruit_EPD.cpp
+++ b/src/Adafruit_EPD.cpp
@@ -647,7 +647,7 @@ void Adafruit_EPD::csHigh() {
   digitalWrite(_cs_pin, HIGH);
 #endif
 
-  if ( _isInTransaction ) {
+  if (_isInTransaction) {
     spi_dev->endTransaction();
     _isInTransaction = false;
   }
@@ -659,7 +659,7 @@ void Adafruit_EPD::csHigh() {
 */
 /**************************************************************************/
 void Adafruit_EPD::csLow() {
-  if ( ! _isInTransaction ) {
+  if (! _isInTransaction) {
     spi_dev->beginTransaction();
     _isInTransaction = true;
   }


### PR DESCRIPTION
fixed blocking of SPI at least on ESP32
#35 
ESP32 uses a MUTEX to handle SPI transactions.
So calling beginTransaction twice in a row will block the device.
This happens in current code, if SRAM is used or a display (like 2,7" tricolor IL91874) which uses singleByteTxns = true
Both will call beginTransaction twice in a row and then the device will block for ever in
cores\esp32\esp32-hal-spi.h SPI_MUTEX_LOCK();