### PR TITLE
alias the BN to the B74

### DIFF
--- a/examples/ThinkInk_mono/ThinkInk_mono.ino
+++ b/examples/ThinkInk_mono/ThinkInk_mono.ino
@@ -33,6 +33,7 @@ ThinkInk_213_Mono_B72 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 // 2.13" Monochrome displays with 250x122 pixels and SSD1680 chipset
 //ThinkInk_213_Mono_BN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_213_Mono_B74 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 // 2.13" Monochrome displays with 212x104 pixels and UC8151D chipset
 //ThinkInk_213_Mono_M21 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/src/panels/ThinkInk_213_Mono_BN.h
+++ b/src/panels/ThinkInk_213_Mono_BN.h
@@ -34,4 +34,6 @@ public:
   }
 };
 
+typedef ThinkInk_213_Mono_BN ThinkInk_213_Mono_B74;
+
 #endif // _THINKINK_213_MONO_BN_H


### PR DESCRIPTION
tested with a 2.13" w/SSD1680