### PR TITLE
Fix warnings

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -11,7 +11,7 @@ jobs:
         arduino-platform:
           - 'uno'
           - 'leonardo'
-          - 'atmega2560'
+          - 'mega2560'
           - 'esp8266'
           - 'esp32'
           - 'trinket_m0'

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -5,7 +5,21 @@ on: [pull_request, push, repository_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+    strategy:
+      fail-fast: false
+      matrix:
+        arduino-platform:
+          - 'uno'
+          - 'leonardo'
+          - 'atmega2560'
+          - 'esp8266'
+          - 'esp32'
+          - 'trinket_m0'
+          - 'cpb'
+          - 'cpx'
+          - 'metro_m0'
+          - 'metro_m4_tinyusb'
+
     steps:
     - uses: actions/setup-python@v1
       with:
@@ -26,10 +40,30 @@ jobs:
         git clone --quiet https://github.com/adafruit/Adafruit_SPIFlash.git /home/runner/Arduino/libraries/Adafruit_SPIFlash
 
     - name: test platforms
-      run: python3 ci/build_platform.py main_platforms metro_m4_tinyusb cpb cpx
+      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
+
+  clang_and_doxy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Checkout adafruit/ci-arduino
+      uses: actions/checkout@v2
+      with:
+         repository: adafruit/ci-arduino
+         path: ci
+
+    - name: pre-install
+      run: bash ci/actions_install.sh
 
     - name: clang
-      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
+      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r .
 
     - name: doxygen
       env:

--- a/examples/EPDTest/EPDTest.ino
+++ b/examples/EPDTest/EPDTest.ino
@@ -103,7 +103,7 @@ void loop() {
 }
 
 
-void testdrawtext(char *text, uint16_t color) {
+void testdrawtext(const char *text, uint16_t color) {
   display.setCursor(0, 0);
   display.setTextColor(color);
   display.setTextWrap(true);

--- a/examples/GizmoTest/GizmoTest.ino
+++ b/examples/GizmoTest/GizmoTest.ino
@@ -84,7 +84,7 @@ void loop() {
 }
 
 
-void testdrawtext(char *text, uint16_t color) {
+void testdrawtext(const char *text, uint16_t color) {
   display.setCursor(0, 0);
   display.setTextColor(color);
   display.setTextWrap(true);

--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -91,7 +91,7 @@ void loop() {
 }
 
 
-void testdrawtext(char *text, uint16_t color) {
+void testdrawtext(const char *text, uint16_t color) {
   display.setCursor(0, 0);
   display.setTextColor(color);
   display.setTextWrap(true);

--- a/examples/ThinkInk_mono/ThinkInk_mono.ino
+++ b/examples/ThinkInk_mono/ThinkInk_mono.ino
@@ -101,7 +101,7 @@ void loop() {
 }
 
 
-void testdrawtext(char *text, uint16_t color) {
+void testdrawtext(const char *text, uint16_t color) {
   display.setCursor(0, 0);
   display.setTextColor(color);
   display.setTextWrap(true);

--- a/examples/ThinkInk_tricolor/ThinkInk_tricolor.ino
+++ b/examples/ThinkInk_tricolor/ThinkInk_tricolor.ino
@@ -96,7 +96,7 @@ void loop() {
 }
 
 
-void testdrawtext(char *text, uint16_t color) {
+void testdrawtext(const char *text, uint16_t color) {
   display.setCursor(0, 0);
   display.setTextColor(color);
   display.setTextWrap(true);

--- a/examples/acep_7ColorTest/acep_7ColorTest.ino
+++ b/examples/acep_7ColorTest/acep_7ColorTest.ino
@@ -81,7 +81,7 @@ void loop() {
 
 #define BUFFPIXEL 20
 
-bool bmpDraw(char *filename, int16_t x, int16_t y) {
+bool bmpDraw(const char *filename, int16_t x, int16_t y) {
   File     bmpFile;
   int      bmpWidth, bmpHeight;   // W+H in pixels
   uint8_t  bmpDepth;              // Bit depth (currently must be 24)
@@ -103,7 +103,7 @@ bool bmpDraw(char *filename, int16_t x, int16_t y) {
   Serial.println('\'');
 
   // Open requested file on SD card
-  if ((bmpFile = fatfs.open(filename, FILE_READ)) == NULL) {
+  if ((bmpFile = fatfs.open(filename, FILE_READ)) == false) {
     Serial.print(F("File not found"));
     return false;
   }

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -158,7 +158,7 @@ void testlines(uint16_t color) {
   display.display();
 }
 
-void testdrawtext(char *text, uint16_t color) {
+void testdrawtext(const char *text, uint16_t color) {
   display.clearBuffer();
   display.setCursor(5, 5);
   display.setTextColor(color);

--- a/src/Adafruit_EPD.cpp
+++ b/src/Adafruit_EPD.cpp
@@ -312,6 +312,7 @@ void Adafruit_EPD::writeSRAMFramebufferToEPD(uint16_t SRAM_buffer_addr,
                                              uint32_t buffer_size,
                                              uint8_t EPDlocation,
                                              bool invertdata) {
+  (void)invertdata;
   uint8_t c;
   // use SRAM
   sram.csLow();
@@ -350,8 +351,6 @@ void Adafruit_EPD::writeSRAMFramebufferToEPD(uint16_t SRAM_buffer_addr,
 */
 /**************************************************************************/
 void Adafruit_EPD::display(bool sleep) {
-  uint8_t c;
-
 #ifdef EPD_DEBUG
   Serial.println("  Powering Up");
 #endif

--- a/src/Adafruit_MCPSRAM.cpp
+++ b/src/Adafruit_MCPSRAM.cpp
@@ -146,7 +146,7 @@ void Adafruit_MCPSRAM::write(uint16_t addr, uint8_t *buf, uint16_t num,
   }
 
   // write buffer of data
-  for (int i = 0; i < num; i++) {
+  for (uint16_t i = 0; i < num; i++) {
 
     uint8_t d = buf[i];
 

--- a/src/Adafruit_MCPSRAM.cpp
+++ b/src/Adafruit_MCPSRAM.cpp
@@ -224,7 +224,7 @@ void Adafruit_MCPSRAM::read(uint16_t addr, uint8_t *buf, uint16_t num,
   }
 
   // read data into buffer
-  for (int i = 0; i < num; i++) {
+  for (uint16_t i = 0; i < num; i++) {
 
     if (hwSPI) {
       buf[i] = _spi->transfer(0x00);

--- a/src/drivers/Adafruit_ACeP.cpp
+++ b/src/drivers/Adafruit_ACeP.cpp
@@ -250,8 +250,6 @@ void Adafruit_ACEP::begin(bool reset) {
 */
 /**************************************************************************/
 void Adafruit_ACEP::display(bool sleep) {
-  uint8_t c;
-
 #ifdef EPD_DEBUG
   Serial.println("  Powering Up");
 #endif
@@ -301,9 +299,6 @@ void Adafruit_ACEP::display(bool sleep) {
 */
 /**************************************************************************/
 void Adafruit_ACEP::update(void) {
-
-  uint8_t buf[4];
-
   EPD_command(ACEP_POWER_ON);
   busy_wait();
   EPD_command(ACEP_DISPLAY_REFRESH);
@@ -374,6 +369,7 @@ void Adafruit_ACEP::powerDown(void) {
 */
 /**************************************************************************/
 uint8_t Adafruit_ACEP::writeRAMCommand(uint8_t index) {
+  (void)index;
   return EPD_command(ACEP_DTM, false);
 }
 
@@ -384,4 +380,7 @@ uint8_t Adafruit_ACEP::writeRAMCommand(uint8_t index) {
     @param y Y address counter value
 */
 /**************************************************************************/
-void Adafruit_ACEP::setRAMAddress(uint16_t x, uint16_t y) {}
+void Adafruit_ACEP::setRAMAddress(uint16_t x, uint16_t y) {
+  (void)x;
+  (void)y;
+}

--- a/src/drivers/Adafruit_EK79686.cpp
+++ b/src/drivers/Adafruit_EK79686.cpp
@@ -148,8 +148,6 @@ void Adafruit_EK79686::update() {
 */
 /**************************************************************************/
 void Adafruit_EK79686::powerUp() {
-  uint8_t buf[5];
-
   hardwareReset();
   delay(10);
 
@@ -208,4 +206,7 @@ uint8_t Adafruit_EK79686::writeRAMCommand(uint8_t index) {
     @param y Y address counter value
 */
 /**************************************************************************/
-void Adafruit_EK79686::setRAMAddress(uint16_t x, uint16_t y) {}
+void Adafruit_EK79686::setRAMAddress(uint16_t x, uint16_t y) {
+  (void)x;
+  (void)y;
+}

--- a/src/drivers/Adafruit_IL0373.cpp
+++ b/src/drivers/Adafruit_IL0373.cpp
@@ -1,6 +1,9 @@
 #include "Adafruit_IL0373.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW IL0373_DTM1
+#define EPD_RAM_RED IL0373_DTM2
+
 #define BUSY_WAIT 100
 
 // clang-format off

--- a/src/drivers/Adafruit_IL0373.cpp
+++ b/src/drivers/Adafruit_IL0373.cpp
@@ -209,12 +209,13 @@ uint8_t Adafruit_IL0373::writeRAMCommand(uint8_t index) {
 /**************************************************************************/
 void Adafruit_IL0373::setRAMAddress(uint16_t x, uint16_t y) {
   // on this chip we do nothing
+  (void)x;
+  (void)y;
 }
 
 void Adafruit_IL0373::displayPartial(uint16_t x1, uint16_t y1, uint16_t x2,
                                      uint16_t y2) {
   uint8_t buf[7];
-  uint8_t c;
 
   // check rotation, move window around if necessary
   switch (getRotation()) {

--- a/src/drivers/Adafruit_IL0373.h
+++ b/src/drivers/Adafruit_IL0373.h
@@ -32,9 +32,6 @@
 #define IL0373_PARTIAL_ENTER 0x91
 #define IL0373_PARTIAL_EXIT 0x92
 
-#define EPD_RAM_BW IL0373_DTM1
-#define EPD_RAM_RED IL0373_DTM2
-
 /**************************************************************************/
 /*!
     @brief  Class for interfacing with IL0373 EPD drivers

--- a/src/drivers/Adafruit_IL0398.cpp
+++ b/src/drivers/Adafruit_IL0398.cpp
@@ -210,4 +210,6 @@ uint8_t Adafruit_IL0398::writeRAMCommand(uint8_t index) {
 /**************************************************************************/
 void Adafruit_IL0398::setRAMAddress(uint16_t x, uint16_t y) {
   // on this chip we do nothing
+  (void)x;
+  (void)y;
 }

--- a/src/drivers/Adafruit_IL0398.cpp
+++ b/src/drivers/Adafruit_IL0398.cpp
@@ -1,6 +1,9 @@
 #include "Adafruit_IL0398.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW 0x10
+#define EPD_RAM_RED 0x13
+
 #define BUSY_WAIT 500
 
 // clang-format off

--- a/src/drivers/Adafruit_IL0398.h
+++ b/src/drivers/Adafruit_IL0398.h
@@ -4,9 +4,6 @@
 #include "Adafruit_EPD.h"
 #include <Arduino.h>
 
-#define EPD_RAM_BW 0x10
-#define EPD_RAM_RED 0x13
-
 #define IL0398_PANEL_SETTING 0x00
 #define IL0398_POWER_SETTING 0x01
 #define IL0398_POWER_OFF 0x02

--- a/src/drivers/Adafruit_IL91874.cpp
+++ b/src/drivers/Adafruit_IL91874.cpp
@@ -249,4 +249,6 @@ uint8_t Adafruit_IL91874::writeRAMCommand(uint8_t index) {
 /**************************************************************************/
 void Adafruit_IL91874::setRAMAddress(uint16_t x, uint16_t y) {
   // on this chip we do nothing
+  (void)x;
+  (void)y;
 }

--- a/src/drivers/Adafruit_IL91874.cpp
+++ b/src/drivers/Adafruit_IL91874.cpp
@@ -1,6 +1,9 @@
 #include "Adafruit_IL91874.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW 0x10
+#define EPD_RAM_RED 0x13
+
 #define BUSY_WAIT 500
 
 // clang-format off

--- a/src/drivers/Adafruit_IL91874.h
+++ b/src/drivers/Adafruit_IL91874.h
@@ -4,9 +4,6 @@
 #include "Adafruit_EPD.h"
 #include <Arduino.h>
 
-#define EPD_RAM_BW 0x10
-#define EPD_RAM_RED 0x13
-
 #define IL91874_PANEL_SETTING 0x00
 #define IL91874_POWER_SETTING 0x01
 #define IL91874_POWER_OFF 0x02

--- a/src/drivers/Adafruit_SSD1608.cpp
+++ b/src/drivers/Adafruit_SSD1608.cpp
@@ -234,6 +234,7 @@ void Adafruit_SSD1608::powerDown(void) {
 */
 /**************************************************************************/
 uint8_t Adafruit_SSD1608::writeRAMCommand(uint8_t index) {
+  (void)index;
   return EPD_command(SSD1608_WRITE_RAM, false);
 }
 

--- a/src/drivers/Adafruit_SSD1608.cpp
+++ b/src/drivers/Adafruit_SSD1608.cpp
@@ -1,6 +1,8 @@
 #include "Adafruit_SSD1608.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW 0x10
+
 #define BUSY_WAIT 500
 
 const unsigned char LUT_DATA[30] = {

--- a/src/drivers/Adafruit_SSD1608.h
+++ b/src/drivers/Adafruit_SSD1608.h
@@ -4,8 +4,6 @@
 #include "Adafruit_EPD.h"
 #include <Arduino.h>
 
-#define EPD_RAM_BW 0x10
-
 #define SSD1608_DRIVER_CONTROL 0x01
 #define SSD1608_GATE_VOLTAGE 0x03
 #define SSD1608_SOURCE_VOLTAGE 0x04

--- a/src/drivers/Adafruit_SSD1619.cpp
+++ b/src/drivers/Adafruit_SSD1619.cpp
@@ -230,6 +230,9 @@ uint8_t Adafruit_SSD1619::writeRAMCommand(uint8_t index) {
 */
 /**************************************************************************/
 void Adafruit_SSD1619::setRAMAddress(uint16_t x, uint16_t y) {
+  (void)x;
+  (void)y;
+
   uint8_t buf[2];
 
   // set RAM x address count

--- a/src/drivers/Adafruit_SSD1619.cpp
+++ b/src/drivers/Adafruit_SSD1619.cpp
@@ -1,6 +1,9 @@
 #include "Adafruit_SSD1619.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW 0x10
+#define EPD_RAM_RED 0x13
+
 #define BUSY_WAIT 500
 
 // clang-format off

--- a/src/drivers/Adafruit_SSD1619.h
+++ b/src/drivers/Adafruit_SSD1619.h
@@ -4,9 +4,6 @@
 #include "Adafruit_EPD.h"
 #include <Arduino.h>
 
-#define EPD_RAM_BW 0x10
-#define EPD_RAM_RED 0x13
-
 #define SSD1619_DRIVER_CONTROL 0x01
 #define SSD1619_GATE_VOLTAGE 0x03
 #define SSD1619_SOURCE_VOLTAGE 0x04

--- a/src/drivers/Adafruit_SSD1675.cpp
+++ b/src/drivers/Adafruit_SSD1675.cpp
@@ -279,6 +279,9 @@ uint8_t Adafruit_SSD1675::writeRAMCommand(uint8_t index) {
 */
 /**************************************************************************/
 void Adafruit_SSD1675::setRAMAddress(uint16_t x, uint16_t y) {
+  (void)x;
+  (void)y;
+
   uint8_t buf[2];
 
   // Set RAM X address counter

--- a/src/drivers/Adafruit_SSD1675.cpp
+++ b/src/drivers/Adafruit_SSD1675.cpp
@@ -1,6 +1,9 @@
 #include "Adafruit_SSD1675.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW 0x10
+#define EPD_RAM_RED 0x13
+
 #define BUSY_WAIT 500
 
 const unsigned char LUT_DATA[] = {

--- a/src/drivers/Adafruit_SSD1675.h
+++ b/src/drivers/Adafruit_SSD1675.h
@@ -4,9 +4,6 @@
 #include "Adafruit_EPD.h"
 #include <Arduino.h>
 
-#define EPD_RAM_BW 0x10
-#define EPD_RAM_RED 0x13
-
 #define SSD1675_DRIVER_CONTROL 0x01
 #define SSD1675_GATE_VOLTAGE 0x03
 #define SSD1675_SOURCE_VOLTAGE 0x04

--- a/src/drivers/Adafruit_SSD1675B.cpp
+++ b/src/drivers/Adafruit_SSD1675B.cpp
@@ -214,7 +214,7 @@ void Adafruit_SSD1675B::powerUp() {
   buf[2] = LUT_DATA[103];
   EPD_command(SSD1675B_SOURCE_VOLTAGE, buf, 3);
 
-  // Set dummy line period
+  // Set dummy line periodAdafruit_SSD1675B.cpp
   buf[0] = LUT_DATA[105];
   EPD_command(SSD1675B_WRITE_DUMMY, buf, 1);
 
@@ -283,6 +283,8 @@ uint8_t Adafruit_SSD1675B::writeRAMCommand(uint8_t index) {
 */
 /**************************************************************************/
 void Adafruit_SSD1675B::setRAMAddress(uint16_t x, uint16_t y) {
+  (void)x;
+  (void)y;
   uint8_t buf[2];
 
   // Set RAM X address counter

--- a/src/drivers/Adafruit_SSD1675B.cpp
+++ b/src/drivers/Adafruit_SSD1675B.cpp
@@ -1,6 +1,9 @@
 #include "Adafruit_SSD1675B.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW 0x10
+#define EPD_RAM_RED 0x13
+
 #define BUSY_WAIT 500
 
 #define SSD1675B_USELUT

--- a/src/drivers/Adafruit_SSD1675B.cpp
+++ b/src/drivers/Adafruit_SSD1675B.cpp
@@ -214,7 +214,7 @@ void Adafruit_SSD1675B::powerUp() {
   buf[2] = LUT_DATA[103];
   EPD_command(SSD1675B_SOURCE_VOLTAGE, buf, 3);
 
-  // Set dummy line periodAdafruit_SSD1675B.cpp
+  // Set dummy line period
   buf[0] = LUT_DATA[105];
   EPD_command(SSD1675B_WRITE_DUMMY, buf, 1);
 

--- a/src/drivers/Adafruit_SSD1675B.h
+++ b/src/drivers/Adafruit_SSD1675B.h
@@ -4,9 +4,6 @@
 #include "Adafruit_EPD.h"
 #include <Arduino.h>
 
-#define EPD_RAM_BW 0x10
-#define EPD_RAM_RED 0x13
-
 #define SSD1675B_DRIVER_CONTROL 0x01
 #define SSD1675B_GATE_VOLTAGE 0x03
 #define SSD1675B_SOURCE_VOLTAGE 0x04

--- a/src/drivers/Adafruit_SSD1680.cpp
+++ b/src/drivers/Adafruit_SSD1680.cpp
@@ -1,6 +1,9 @@
 #include "Adafruit_SSD1680.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW 0x10
+#define EPD_RAM_RED 0x13
+
 #define BUSY_WAIT 500
 
 // clang-format off

--- a/src/drivers/Adafruit_SSD1680.cpp
+++ b/src/drivers/Adafruit_SSD1680.cpp
@@ -246,6 +246,9 @@ uint8_t Adafruit_SSD1680::writeRAMCommand(uint8_t index) {
 */
 /**************************************************************************/
 void Adafruit_SSD1680::setRAMAddress(uint16_t x, uint16_t y) {
+  (void)x;
+  (void)y;
+
   uint8_t buf[2];
 
   // set RAM x address count

--- a/src/drivers/Adafruit_SSD1680.h
+++ b/src/drivers/Adafruit_SSD1680.h
@@ -4,9 +4,6 @@
 #include "Adafruit_EPD.h"
 #include <Arduino.h>
 
-#define EPD_RAM_BW 0x10
-#define EPD_RAM_RED 0x13
-
 #define SSD1680_DRIVER_CONTROL 0x01
 #define SSD1680_GATE_VOLTAGE 0x03
 #define SSD1680_SOURCE_VOLTAGE 0x04

--- a/src/drivers/Adafruit_SSD1681.cpp
+++ b/src/drivers/Adafruit_SSD1681.cpp
@@ -168,9 +168,6 @@ void Adafruit_SSD1681::updatePartial(void) {
 
 void Adafruit_SSD1681::displayPartial(uint16_t x1, uint16_t y1, uint16_t x2,
                                       uint16_t y2) {
-  uint8_t buf[7];
-  uint8_t c;
-
   // check rotation, move window around if necessary
   switch (getRotation()) {
   case 0:

--- a/src/drivers/Adafruit_SSD1681.cpp
+++ b/src/drivers/Adafruit_SSD1681.cpp
@@ -1,6 +1,9 @@
 #include "Adafruit_SSD1681.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW 0x10
+#define EPD_RAM_RED 0x13
+
 #define BUSY_WAIT 500
 
 // clang-format off

--- a/src/drivers/Adafruit_SSD1681.h
+++ b/src/drivers/Adafruit_SSD1681.h
@@ -4,9 +4,6 @@
 #include "Adafruit_EPD.h"
 #include <Arduino.h>
 
-#define EPD_RAM_BW 0x10
-#define EPD_RAM_RED 0x13
-
 #define SSD1681_DRIVER_CONTROL 0x01
 #define SSD1681_GATE_VOLTAGE 0x03
 #define SSD1681_SOURCE_VOLTAGE 0x04

--- a/src/drivers/Adafruit_UC8151D.cpp
+++ b/src/drivers/Adafruit_UC8151D.cpp
@@ -124,8 +124,6 @@ void Adafruit_UC8151D::update() {
 */
 /**************************************************************************/
 void Adafruit_UC8151D::powerUp() {
-  uint8_t buf[5];
-
   // Demo code resets 3 times!
   hardwareReset();
   delay(10);
@@ -192,7 +190,10 @@ uint8_t Adafruit_UC8151D::writeRAMCommand(uint8_t index) {
     @param y Y address counter value
 */
 /**************************************************************************/
-void Adafruit_UC8151D::setRAMAddress(uint16_t x, uint16_t y) {}
+void Adafruit_UC8151D::setRAMAddress(uint16_t x, uint16_t y) {
+  (void)x;
+  (void)y;
+}
 
 /**************************************************************************/
 /*!
@@ -202,7 +203,6 @@ void Adafruit_UC8151D::setRAMAddress(uint16_t x, uint16_t y) {}
 void Adafruit_UC8151D::displayPartial(uint16_t x1, uint16_t y1, uint16_t x2,
                                       uint16_t y2) {
   uint8_t buf[7];
-  uint8_t c;
 
   // check rotation, move window around if necessary
   switch (getRotation()) {

--- a/src/drivers/Adafruit_UC8151D.cpp
+++ b/src/drivers/Adafruit_UC8151D.cpp
@@ -1,6 +1,8 @@
 #include "Adafruit_UC8151D.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW 0x10
+
 #define BUSY_WAIT 500
 
 /**************************************************************************/

--- a/src/drivers/Adafruit_UC8151D.h
+++ b/src/drivers/Adafruit_UC8151D.h
@@ -4,8 +4,6 @@
 #include "Adafruit_EPD.h"
 #include <Arduino.h>
 
-#define EPD_RAM_BW 0x10
-
 #define UC8151D_PSR 0x00
 #define UC8151D_PWR 0x01
 #define UC8151D_POF 0x02

--- a/src/drivers/Adafruit_UC8276.cpp
+++ b/src/drivers/Adafruit_UC8276.cpp
@@ -145,8 +145,6 @@ void Adafruit_UC8276::update() {
 */
 /**************************************************************************/
 void Adafruit_UC8276::powerUp() {
-  uint8_t buf[5];
-
   hardwareReset();
 
   const uint8_t *init_code = uc8276_default_init_code;
@@ -205,6 +203,8 @@ uint8_t Adafruit_UC8276::writeRAMCommand(uint8_t index) {
 /**************************************************************************/
 void Adafruit_UC8276::setRAMAddress(uint16_t x, uint16_t y) {
   // not used in this chip!
+  (void)x;
+  (void)y;
 }
 
 /**************************************************************************/
@@ -217,4 +217,8 @@ void Adafruit_UC8276::setRAMAddress(uint16_t x, uint16_t y) {
 void Adafruit_UC8276::setRAMWindow(uint16_t x1, uint16_t y1, uint16_t x2,
                                    uint16_t y2) {
   // not used in this chip!
+  (void)x1;
+  (void)y1;
+  (void)x2;
+  (void)y2;
 }

--- a/src/drivers/Adafruit_UC8276.cpp
+++ b/src/drivers/Adafruit_UC8276.cpp
@@ -1,6 +1,9 @@
 #include "Adafruit_UC8276.h"
 #include "Adafruit_EPD.h"
 
+#define EPD_RAM_BW 0x10
+#define EPD_RAM_RED 0x13
+
 #define BUSY_WAIT 500
 
 // clang-format off

--- a/src/drivers/Adafruit_UC8276.h
+++ b/src/drivers/Adafruit_UC8276.h
@@ -4,9 +4,6 @@
 #include "Adafruit_EPD.h"
 #include <Arduino.h>
 
-#define EPD_RAM_BW 0x10
-#define EPD_RAM_RED 0x13
-
 #define UC8276_PANELSETTING 0x00
 #define UC8276_POWEROFF 0x02
 #define UC8276_POWERON 0x04

--- a/src/panels/ThinkInk_270_Grayscale4_W3.h
+++ b/src/panels/ThinkInk_270_Grayscale4_W3.h
@@ -87,11 +87,11 @@ public:
   ThinkInk_270_Grayscale4_W3(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                              int8_t CS, int8_t SRCS, int8_t MISO,
                              int8_t BUSY = -1)
-      : Adafruit_IL91874(264, 176, SID, SCLK, DC, RST, CS, SRCS, MISO, -1){};
+      : Adafruit_IL91874(264, 176, SID, SCLK, DC, RST, CS, SRCS, MISO, BUSY){};
 
   ThinkInk_270_Grayscale4_W3(int8_t DC, int8_t RST, int8_t CS, int8_t SRCS,
                              int8_t BUSY = -1, SPIClass *spi = &SPI)
-      : Adafruit_IL91874(264, 176, DC, RST, CS, SRCS, -1, spi){};
+      : Adafruit_IL91874(264, 176, DC, RST, CS, SRCS, BUSY, spi){};
 
   void begin(thinkinkmode_t mode = THINKINK_MONO) {
     Adafruit_IL91874::begin(true);

--- a/src/panels/ThinkInk_270_Tricolor_C44.h
+++ b/src/panels/ThinkInk_270_Tricolor_C44.h
@@ -27,11 +27,11 @@ public:
   ThinkInk_270_Tricolor_C44(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                             int8_t CS, int8_t SRCS, int8_t MISO,
                             int8_t BUSY = -1)
-      : Adafruit_IL91874(264, 176, SID, SCLK, DC, RST, CS, SRCS, MISO, -1){};
+      : Adafruit_IL91874(264, 176, SID, SCLK, DC, RST, CS, SRCS, MISO, BUSY){};
 
   ThinkInk_270_Tricolor_C44(int8_t DC, int8_t RST, int8_t CS, int8_t SRCS,
                             int8_t BUSY = -1, SPIClass *spi = &SPI)
-      : Adafruit_IL91874(264, 176, DC, RST, CS, SRCS, -1, spi){};
+      : Adafruit_IL91874(264, 176, DC, RST, CS, SRCS, BUSY, spi){};
 
   void begin(thinkinkmode_t mode = THINKINK_TRICOLOR) {
     Adafruit_IL91874::begin(true);

--- a/src/panels/ThinkInk_270_Tricolor_Z70.h
+++ b/src/panels/ThinkInk_270_Tricolor_Z70.h
@@ -9,11 +9,11 @@ public:
   ThinkInk_270_Tricolor_Z70(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST,
                             int8_t CS, int8_t SRCS, int8_t MISO,
                             int8_t BUSY = -1)
-      : Adafruit_EK79686(264, 176, SID, SCLK, DC, RST, CS, SRCS, MISO, -1){};
+      : Adafruit_EK79686(264, 176, SID, SCLK, DC, RST, CS, SRCS, MISO, BUSY){};
 
   ThinkInk_270_Tricolor_Z70(int8_t DC, int8_t RST, int8_t CS, int8_t SRCS,
                             int8_t BUSY = -1, SPIClass *spi = &SPI)
-      : Adafruit_EK79686(264, 176, DC, RST, CS, SRCS, -1, spi){};
+      : Adafruit_EK79686(264, 176, DC, RST, CS, SRCS, BUSY, spi){};
 
   void begin(thinkinkmode_t mode = THINKINK_TRICOLOR) {
     Adafruit_EK79686::begin(true);


### PR DESCRIPTION
move EPD_RAM_BW / EPD_RAM_RED into c file to prevent redefine warnings
fix unused variables in drivers
fix missing BUSY in constructor
fix warnings with const char* and file bool op