### PR TITLE
Fix red inversion regardless of reset pin value

### DIFF
--- a/src/panels/ThinkInk_270_Tricolor_C44.h
+++ b/src/panels/ThinkInk_270_Tricolor_C44.h
@@ -35,8 +35,8 @@ public:
 
   void begin(thinkinkmode_t mode = THINKINK_TRICOLOR) {
     Adafruit_IL91874::begin(true);
-    setBlackBuffer(0, true);
-    setColorBuffer(1, true);
+    setBlackBuffer(0, _reset_pin < 0);
+    setColorBuffer(1, _reset_pin < 0);
 
     _epd_init_code = ti_270c44_tri_init_code;
     _epd_lut_code = NULL;

--- a/src/panels/ThinkInk_270_Tricolor_C44.h
+++ b/src/panels/ThinkInk_270_Tricolor_C44.h
@@ -16,6 +16,7 @@ static const uint8_t ti_270c44_tri_init_code[] {
     0xF8, 2, 0x60, 0xA5, // boost
     0xF8, 2, 0x73, 0x23, // boost
     0xF8, 2, 0x7C, 0x00, // boost
+    IL91874_CDI, 1, 0x97,
 
     0xFE // EOM
 };
@@ -35,8 +36,8 @@ public:
 
   void begin(thinkinkmode_t mode = THINKINK_TRICOLOR) {
     Adafruit_IL91874::begin(true);
-    setBlackBuffer(0, _reset_pin < 0);
-    setColorBuffer(1, _reset_pin < 0);
+    setBlackBuffer(0, true);
+    setColorBuffer(1, false);
 
     _epd_init_code = ti_270c44_tri_init_code;
     _epd_lut_code = NULL;


### PR DESCRIPTION
Fixes #52. This fixes a weird error where when the reset pin is passed as anything other than -1, the colors invert.