### PR TITLE
Fix rotation calculation for EPD modules

### DIFF
--- a/src/Adafruit_EPD.cpp
+++ b/src/Adafruit_EPD.cpp
@@ -224,12 +224,6 @@ void Adafruit_EPD::drawPixel(int16_t x, int16_t y, uint16_t color) {
 
   uint8_t *black_pBuf, *color_pBuf;
 
-  // deal with non-8-bit heights
-  uint16_t _HEIGHT = HEIGHT;
-  if (_HEIGHT % 8 != 0) {
-    _HEIGHT += 8 - (_HEIGHT % 8);
-  }
-
   // check rotation, move pixel around if necessary
   switch (getRotation()) {
   case 1:
@@ -238,12 +232,18 @@ void Adafruit_EPD::drawPixel(int16_t x, int16_t y, uint16_t color) {
     break;
   case 2:
     x = WIDTH - x - 1;
-    y = _HEIGHT - y - 1;
+    y = HEIGHT - y - 1;
     break;
   case 3:
     EPD_swap(x, y);
-    y = _HEIGHT - y - 1;
+    y = HEIGHT - y - 1;
     break;
+  }
+
+  // deal with non-8-bit heights
+  uint16_t _HEIGHT = HEIGHT;
+  if (_HEIGHT % 8 != 0) {
+    _HEIGHT += 8 - (_HEIGHT % 8);
   }
   uint16_t addr = ((uint32_t)(WIDTH - 1 - x) * (uint32_t)_HEIGHT + y) / 8;
   uint8_t black_c, color_c;


### PR DESCRIPTION
This code was conflating the need to adjust address offset with the rotation
calculation.  The rotation calculation should be done in a coordinate
system equal to the display height and width.  The address offset must be
done using a 'height' that represents the total number of addressable bytes
of memory configured.

---
I noticed this problem using the Adafruit 2.13" Monochrome eInk board, but I believe the issue will exist for most boards in this library.  When using the `setRotation` function with values of 2 or 3 (180 or 270 degrees of rotation), the image is shifted off of the panel by a few pixels (6 pixels in the case of this board).  Any board whose height is not a multiple of 8 will have this problem.

Below is a test program and an image that shows it running at rotations 0, 1, 2, and 3.  The last two are shifted down too far.  This patch fixes the issue.  I don't have another board to test this on, but if I understand the problem correctly, this should work with all of the other boards as well.

```
#include "Adafruit_ThinkInk.h"

#define EPD_CS      A0
#define EPD_DC      A1
#define SRAM_CS     A2
#define SD_CS       A3
#define EPD_RESET   A4
#define EPD_BUSY    A5

ThinkInk_213_Mono_BN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

void setup() {
  display.begin();
  display.setTextColor(EPD_BLACK);
}

void pattern(uint8_t rotation) {
  display.clearBuffer();
  display.setRotation(rotation);
  display.setCursor(2, 2);
  display.print("rotate: ");
  display.print(rotation);
  display.drawRect(0, 0, display.width(), display.height(), EPD_BLACK);
  display.drawLine(0, 0, display.width()-1, display.height()-1, EPD_BLACK);
  display.display();
}

void loop() {
  pattern(0);
  delay(1000);

  pattern(1);
  delay(1000);

  pattern(2);
  delay(1000);

  pattern(3);
  delay(1000);
}
```
![rotate-bug](https://user-images.githubusercontent.com/8703452/172275789-4717b6a7-537b-416c-b1fa-dac446a587e5.png)