### PR TITLE
Fix a couple of warnings

### DIFF
--- a/src/Adafruit_MCPSRAM.cpp
+++ b/src/Adafruit_MCPSRAM.cpp
@@ -229,6 +229,7 @@ void Adafruit_MCPSRAM::read(uint16_t addr, uint8_t *buf, uint16_t num,
     if (hwSPI) {
       buf[i] = _spi->transfer(0x00);
     } else {
+      buf[i] = 0;
       for (uint8_t bit = 0x80; bit; bit >>= 1) {
 #ifdef HAVE_PORTREG
         *clkport &= ~clkpinmask;

--- a/src/panels/ThinkInk_420_Tricolor_Z21.h
+++ b/src/panels/ThinkInk_420_Tricolor_Z21.h
@@ -16,6 +16,7 @@ public:
       : Adafruit_UC8276(300, 400, DC, RST, CS, SRCS, BUSY, spi){};
 
   void begin(thinkinkmode_t mode = THINKINK_TRICOLOR) {
+    (void)mode;
     Adafruit_EPD::begin(true);
     setBlackBuffer(0, true);
     setColorBuffer(1, false);


### PR DESCRIPTION
come across these warnings when doing some work with nrf52.
- suppress unused warnings
- soft spi read and shift 8 times for a byte, though since we do |= without zero first, gcc throw warnings https://github.com/adafruit/Adafruit_EPD/runs/6867499218?check_suite_focus=true#step:7:26

```
/home/runner/Arduino/libraries/Adafruit_EPD/src/Adafruit_MCPSRAM.cpp: In member function 'uint8_t Adafruit_MCPSRAM::read8(uint16_t, uint8_t)':
  /home/runner/Arduino/libraries/Adafruit_EPD/src/Adafruit_MCPSRAM.cpp:241:24: warning: 'c' may be used uninitialized in this function [-Wmaybe-uninitialized]
    241 |         buf[i] = (buf[i] << 1) | digitalRead(_miso);
        |                   ~~~~~^
  /home/runner/Arduino/libraries/Adafruit_EPD/src/Adafruit_MCPSRAM.cpp:259:11: note: 'c' was declared here
    259 |   uint8_t c;
        |           ^
```