### PR TITLE
Fix deprecated

### DIFF
--- a/src/Adafruit_MCPSRAM.h
+++ b/src/Adafruit_MCPSRAM.h
@@ -37,7 +37,7 @@ public:
   void csLow();
 
 private:
-  boolean hwSPI; ///< true if using hardware SPI
+  bool hwSPI; ///< true if using hardware SPI
 #ifdef HAVE_PORTREG
   PortReg *mosiport, *clkport, *csport, *misoport;
   PortMask mosipinmask, clkpinmask, cspinmask, misopinmask;

--- a/src/drivers/Adafruit_ACeP.cpp
+++ b/src/drivers/Adafruit_ACeP.cpp
@@ -129,7 +129,7 @@ void Adafruit_ACEP::deGhost() {
   uint32_t remaining = (600UL * 448UL / 2);
   while (remaining) {
     uint8_t block[256];
-    uint32_t numbytes = min(remaining, sizeof(block));
+    uint32_t numbytes = min(remaining, (uint32_t)sizeof(block));
     memset(block, 0x77, numbytes);
     EPD_data(block, numbytes);
     remaining -= numbytes;

--- a/src/drivers/Adafruit_UC8151D.cpp
+++ b/src/drivers/Adafruit_UC8151D.cpp
@@ -305,7 +305,7 @@ void Adafruit_UC8151D::displayPartial(uint16_t x1, uint16_t y1, uint16_t x2,
     uint32_t offset = 0;
     uint8_t mcp_buf[16];
     while (remaining) {
-      uint8_t to_xfer = min(sizeof(mcp_buf), remaining);
+      uint8_t to_xfer = min((uint32_t)sizeof(mcp_buf), remaining);
 
       sram.read(buffer2_addr + offset, mcp_buf, to_xfer);
       sram.write(buffer1_addr + offset, mcp_buf, to_xfer);


### PR DESCRIPTION
Hello,

I just bought a eink display from AdaFruit, as well as STM32 feather board, and wanted to give a try to this library.
However, out of the box, I found two errors and a warning when using my usual toolchain (Platformio + STM32duino).
- The warning refers to the use of the `boolean` Arduino type. As stated [here](https://www.arduino.cc/reference/en/language/variables/data-types/boolean/), this type is deprecated and totally equivalent to the standard `bool` type.  While this is not a blocking issue, I always intend as fixing every warning when coding, so that I can see in a glimpse in my terminal that everything went well.
- The errors are related to calling the `min()` function with different data type for the arguments. As one can see [here](https://cplusplus.com/reference/algorithm/min/), both arguments must be of the same type, and these calls mixed `uint32_t` type with the result of the `sizeof()` operator, which returns a `size_t`, as stated [here](https://en.cppreference.com/w/cpp/language/sizeof). This is a blocking error with my toolchain, and could be resolved easily by casting the result of the `sizeof()` operator used as one of the argument to match the other.

I can't see any use case in which these changes would cause any issue, as one commit is the resolution of a deprecated type to the matching standard type, and the other tend to follow the C++ correct syntax.

Big love to AdaFruit and its wonderful products!
