### PR TITLE
fix compile error for STM32-based boards

### DIFF
--- a/src/drivers/Adafruit_ACeP.cpp
+++ b/src/drivers/Adafruit_ACeP.cpp
@@ -129,7 +129,7 @@ void Adafruit_ACEP::deGhost() {
   uint32_t remaining = (600UL * 448UL / 2);
   while (remaining) {
     uint8_t block[256];
-    uint32_t numbytes = min(remaining, sizeof(block));
+    uint32_t numbytes = min((unsigned int)remaining, sizeof(block));
     memset(block, 0x77, numbytes);
     EPD_data(block, numbytes);
     remaining -= numbytes;

--- a/src/drivers/Adafruit_UC8151D.cpp
+++ b/src/drivers/Adafruit_UC8151D.cpp
@@ -305,7 +305,7 @@ void Adafruit_UC8151D::displayPartial(uint16_t x1, uint16_t y1, uint16_t x2,
     uint32_t offset = 0;
     uint8_t mcp_buf[16];
     while (remaining) {
-      uint8_t to_xfer = min(sizeof(mcp_buf), remaining);
+      uint8_t to_xfer = min(sizeof(mcp_buf), (unsigned int)remaining);
 
       sram.read(buffer2_addr + offset, mcp_buf, to_xfer);
       sram.write(buffer1_addr + offset, mcp_buf, to_xfer);


### PR DESCRIPTION
As detailed in #69 this library does not compile on STM32-based boards because of a type expectation in `st_algobase.h`. This cast fixes that issue.
