### PR TITLE
Updating examples for Feather RP2040 ThinkInk

### DIFF
--- a/examples/EPDTest/EPDTest.ino
+++ b/examples/EPDTest/EPDTest.ino
@@ -9,12 +9,21 @@
 
 #include "Adafruit_EPD.h"
 
-
-#define EPD_CS     10
-#define EPD_DC      9
-#define SRAM_CS     11
-#define EPD_RESET   5 // can set to -1 and share with microcontroller Reset!
+#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
+#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
+#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
+#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
+#define SRAM_CS     -1  // use onboard RAM
+#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
+#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#else
+#define EPD_DC      10
+#define EPD_CS      9
 #define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS     6
+#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI     &SPI // primary SPI
+#endif
 
 // Uncomment the following line if you are using 1.54" EPD with IL0373
 //Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/EPDTest/EPDTest.ino
+++ b/examples/EPDTest/EPDTest.ino
@@ -26,50 +26,50 @@
 #endif
 
 // Uncomment the following line if you are using 1.54" EPD with IL0373
-//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 // Uncomment the following line if you are using 1.54" EPD with SSD1680
-//Adafruit_SSD1680 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1680 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 // Uncomment the following line if you are using 1.54" EPD with SSD1608
-//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 // Uncomment the following line if you are using 1.54" EPD with SSD1681
-//Adafruit_SSD1681 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1681 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 // Uncomment the following line if you are using 1.54" EPD with UC8151D
-//Adafruit_UC8151D display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_UC8151D display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 
 //Uncomment the following line if you are using 2.13" EPD with SSD1680
-//Adafruit_SSD1680 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1680 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.13" EPD with SSD1675
-//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.13" EPD with SSD1675B
-//Adafruit_SSD1675B display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1675B display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.13" EPD with UC8151D
-//Adafruit_UC8151D display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_UC8151D display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 //Uncomment the following line if you are using 2.13" EPD with IL0373
-Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 //#define FLEXIBLE_213
 
 
 //Uncomment the following line if you are using 2.7" EPD with IL91874
-//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS);
+//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.7" EPD with EK79686
-//Adafruit_EK79686 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_EK79686 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 
 // Uncomment the following line if you are using 2.9" EPD with IL0373
-//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 //#define FLEXIBLE_290
 
 // Uncomment the following line if you are using 2.9" EPD with SSD1680
-//Adafruit_SSD1680 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1680 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.9" EPD with UC8151D
-//Adafruit_UC8151D display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_UC8151D display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 
 #define COLOR1 EPD_BLACK

--- a/examples/EPDTest/EPDTest.ino
+++ b/examples/EPDTest/EPDTest.ino
@@ -9,78 +9,88 @@
 
 #include "Adafruit_EPD.h"
 
-#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
-#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
-#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
-#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
-#define SRAM_CS     -1  // use onboard RAM
-#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
-#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#ifdef ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK // detects if compiling for
+                                                // Feather RP2040 ThinkInk
+#define EPD_DC PIN_EPD_DC       // ThinkInk 24-pin connector DC
+#define EPD_CS PIN_EPD_CS       // ThinkInk 24-pin connector CS
+#define EPD_BUSY PIN_EPD_BUSY   // ThinkInk 24-pin connector Busy
+#define SRAM_CS -1              // use onboard RAM
+#define EPD_RESET PIN_EPD_RESET // ThinkInk 24-pin connector Reset
+#define EPD_SPI &SPI1           // secondary SPI for ThinkInk
 #else
-#define EPD_DC      10
-#define EPD_CS      9
-#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
-#define SRAM_CS     6
-#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
-#define EPD_SPI     &SPI // primary SPI
+#define EPD_DC 10
+#define EPD_CS 9
+#define EPD_BUSY 7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS 6
+#define EPD_RESET 8  // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI &SPI // primary SPI
 #endif
 
 // Uncomment the following line if you are using 1.54" EPD with IL0373
-//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 // Uncomment the following line if you are using 1.54" EPD with SSD1680
-//Adafruit_SSD1680 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1680 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 // Uncomment the following line if you are using 1.54" EPD with SSD1608
-//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 // Uncomment the following line if you are using 1.54" EPD with SSD1681
-//Adafruit_SSD1681 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1681 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 // Uncomment the following line if you are using 1.54" EPD with UC8151D
-//Adafruit_UC8151D display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_UC8151D display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
-
-//Uncomment the following line if you are using 2.13" EPD with SSD1680
-//Adafruit_SSD1680 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Uncomment the following line if you are using 2.13" EPD with SSD1680
+// Adafruit_SSD1680 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.13" EPD with SSD1675
-//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.13" EPD with SSD1675B
-//Adafruit_SSD1675B display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1675B display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.13" EPD with UC8151D
-//Adafruit_UC8151D display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_UC8151D display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
-//Uncomment the following line if you are using 2.13" EPD with IL0373
-Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Uncomment the following line if you are using 2.13" EPD with IL0373
+Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
+                        EPD_SPI);
 //#define FLEXIBLE_213
 
-
-//Uncomment the following line if you are using 2.7" EPD with IL91874
-//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Uncomment the following line if you are using 2.7" EPD with IL91874
+// Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.7" EPD with EK79686
-//Adafruit_EK79686 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-
+// Adafruit_EK79686 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.9" EPD with IL0373
-//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-//#define FLEXIBLE_290
+// Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI); #define FLEXIBLE_290
 
 // Uncomment the following line if you are using 2.9" EPD with SSD1680
-//Adafruit_SSD1680 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1680 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // Uncomment the following line if you are using 2.9" EPD with UC8151D
-//Adafruit_UC8151D display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-
+// Adafruit_UC8151D display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 #define COLOR1 EPD_BLACK
 #define COLOR2 EPD_RED
 
-
 void setup() {
   Serial.begin(115200);
-  //while (!Serial) { delay(10); }
+  // while (!Serial) { delay(10); }
   Serial.println("Adafruit EPD test");
-  
+
   display.begin();
 
 #if defined(FLEXIBLE_213) || defined(FLEXIBLE_290)
@@ -91,26 +101,33 @@ void setup() {
 
   // large block of text
   display.clearBuffer();
-  testdrawtext("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a tortor imperdiet posuere. ", COLOR1);
+  testdrawtext(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur "
+      "adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, "
+      "fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor "
+      "neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet "
+      "ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a "
+      "tortor imperdiet posuere. ",
+      COLOR1);
   display.display();
 
   delay(5000);
 
   display.clearBuffer();
-  for (int16_t i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, COLOR1);
+  for (int16_t i = 0; i < display.width(); i += 4) {
+    display.drawLine(0, 0, i, display.height() - 1, COLOR1);
   }
 
-  for (int16_t i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, COLOR2);  // on grayscale this will be mid-gray
+  for (int16_t i = 0; i < display.height(); i += 4) {
+    display.drawLine(display.width() - 1, 0, 0, i,
+                     COLOR2); // on grayscale this will be mid-gray
   }
   display.display();
 }
 
 void loop() {
-  //don't do anything!
+  // don't do anything!
 }
-
 
 void testdrawtext(const char *text, uint16_t color) {
   display.setCursor(0, 0);

--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -9,11 +9,21 @@
 
 #include "Adafruit_ThinkInk.h"
 
-#define EPD_DC      10 // can be any pin, but required!
-#define EPD_CS      9  // can be any pin, but required!
-#define EPD_BUSY    7  // can set to -1 to not use a pin (will wait a fixed delay)
-#define SRAM_CS     6  // can set to -1 to not use a pin (uses a lot of RAM!)
-#define EPD_RESET   8  // can set to -1 and share with chip Reset (can't deep sleep)
+#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
+#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
+#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
+#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
+#define SRAM_CS     -1  // use onboard RAM
+#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
+#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#else
+#define EPD_DC      10
+#define EPD_CS      9
+#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS     6
+#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI     &SPI // primary SPI
+#endif
 
 //ThinkInk_154_Grayscale4_T8 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 //ThinkInk_213_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -9,10 +9,10 @@
 
 #include "Adafruit_ThinkInk.h"
 
-#ifdef(ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK) // detects if compiling for
-                                                 // Feather RP2040 ThinkInk
-#define EPD_DC PIN_EPD_DC                        // ThinkInk 24-pin connector DC
-#define EPD_CS PIN_EPD_CS                        // ThinkInk 24-pin connector CS
+#ifdef ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK // detects if compiling for
+                                                // Feather RP2040 ThinkInk
+#define EPD_DC PIN_EPD_DC       // ThinkInk 24-pin connector DC
+#define EPD_CS PIN_EPD_CS       // ThinkInk 24-pin connector CS
 #define EPD_BUSY PIN_EPD_BUSY   // ThinkInk 24-pin connector Busy
 #define SRAM_CS -1              // use onboard RAM
 #define EPD_RESET PIN_EPD_RESET // ThinkInk 24-pin connector Reset

--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -9,29 +9,33 @@
 
 #include "Adafruit_ThinkInk.h"
 
-#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
-#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
-#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
-#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
-#define SRAM_CS     -1  // use onboard RAM
-#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
-#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#ifdef(ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK) // detects if compiling for
+                                                 // Feather RP2040 ThinkInk
+#define EPD_DC PIN_EPD_DC                        // ThinkInk 24-pin connector DC
+#define EPD_CS PIN_EPD_CS                        // ThinkInk 24-pin connector CS
+#define EPD_BUSY PIN_EPD_BUSY   // ThinkInk 24-pin connector Busy
+#define SRAM_CS -1              // use onboard RAM
+#define EPD_RESET PIN_EPD_RESET // ThinkInk 24-pin connector Reset
+#define EPD_SPI &SPI1           // secondary SPI for ThinkInk
 #else
-#define EPD_DC      10
-#define EPD_CS      9
-#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
-#define SRAM_CS     6
-#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
-#define EPD_SPI     &SPI // primary SPI
+#define EPD_DC 10
+#define EPD_CS 9
+#define EPD_BUSY 7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS 6
+#define EPD_RESET 8  // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI &SPI // primary SPI
 #endif
 
-//ThinkInk_154_Grayscale4_T8 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-//ThinkInk_213_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_154_Grayscale4_T8 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI); ThinkInk_213_Grayscale4_T5 display(EPD_DC, EPD_RESET,
+// EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // 2.9" Grayscale Featherwing or Breakout:
-ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
+                                   EPD_SPI);
 // 4.2" Grayscale display
-//ThinkInk_420_Grayscale4_T2 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_420_Grayscale4_T2 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 #define COLOR1 EPD_BLACK
 #define COLOR2 EPD_LIGHT
@@ -67,16 +71,18 @@ void loop() {
     display.print("Monochrome");
   }
 
-
   gray = !gray;
 
   display.display();
   delay(1000);
 
   display.clearBuffer();
-  display.fillRect(display.width() / 4, 0, display.width() / 4, display.height(), EPD_LIGHT);
-  display.fillRect((display.width() * 2) / 4, 0, display.width() / 4, display.height(), EPD_DARK);
-  display.fillRect((display.width() * 3) / 4, 0, display.width() / 4, display.height(), EPD_BLACK);
+  display.fillRect(display.width() / 4, 0, display.width() / 4,
+                   display.height(), EPD_LIGHT);
+  display.fillRect((display.width() * 2) / 4, 0, display.width() / 4,
+                   display.height(), EPD_DARK);
+  display.fillRect((display.width() * 3) / 4, 0, display.width() / 4,
+                   display.height(), EPD_BLACK);
   display.display();
   delay(2000);
 
@@ -84,7 +90,14 @@ void loop() {
   // large block of text
   display.clearBuffer();
   display.setTextSize(1);
-  testdrawtext("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a tortor imperdiet posuere. ", COLOR1);
+  testdrawtext(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur "
+      "adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, "
+      "fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor "
+      "neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet "
+      "ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a "
+      "tortor imperdiet posuere. ",
+      COLOR1);
   display.display();
   delay(2000);
 
@@ -94,12 +107,12 @@ void loop() {
   }
 
   for (int16_t i = 0; i < display.height(); i += 4) {
-    display.drawLine(display.width() - 1, 0, 0, i, COLOR2); // on grayscale this will be mid-gray
+    display.drawLine(display.width() - 1, 0, 0, i,
+                     COLOR2); // on grayscale this will be mid-gray
   }
   display.display();
   delay(2000);
 }
-
 
 void testdrawtext(const char *text, uint16_t color) {
   display.setCursor(0, 0);

--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -25,13 +25,13 @@
 #define EPD_SPI     &SPI // primary SPI
 #endif
 
-//ThinkInk_154_Grayscale4_T8 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
-//ThinkInk_213_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_154_Grayscale4_T8 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+//ThinkInk_213_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // 2.9" Grayscale Featherwing or Breakout:
-ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 // 4.2" Grayscale display
-//ThinkInk_420_Grayscale4_T2 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_420_Grayscale4_T2 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 #define COLOR1 EPD_BLACK
 #define COLOR2 EPD_LIGHT

--- a/examples/ThinkInk_mono/ThinkInk_mono.ino
+++ b/examples/ThinkInk_mono/ThinkInk_mono.ino
@@ -9,11 +9,21 @@
 
 #include "Adafruit_ThinkInk.h"
 
-#define EPD_CS      9
+#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
+#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
+#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
+#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
+#define SRAM_CS     -1  // use onboard RAM
+#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
+#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#else
 #define EPD_DC      10
+#define EPD_CS      9
+#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
 #define SRAM_CS     6
 #define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
-#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define EPD_SPI     &SPI // primary SPI
+#endif
 
 // 1.54" Monochrome displays with 200x200 pixels and SSD1681 chipset
 //ThinkInk_154_Mono_D67 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/ThinkInk_mono/ThinkInk_mono.ino
+++ b/examples/ThinkInk_mono/ThinkInk_mono.ino
@@ -9,63 +9,64 @@
 
 #include "Adafruit_ThinkInk.h"
 
-#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
-#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
-#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
-#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
-#define SRAM_CS     -1  // use onboard RAM
-#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
-#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#ifdef ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK // detects if compiling for
+                                                // Feather RP2040 ThinkInk
+#define EPD_DC PIN_EPD_DC       // ThinkInk 24-pin connector DC
+#define EPD_CS PIN_EPD_CS       // ThinkInk 24-pin connector CS
+#define EPD_BUSY PIN_EPD_BUSY   // ThinkInk 24-pin connector Busy
+#define SRAM_CS -1              // use onboard RAM
+#define EPD_RESET PIN_EPD_RESET // ThinkInk 24-pin connector Reset
+#define EPD_SPI &SPI1           // secondary SPI for ThinkInk
 #else
-#define EPD_DC      10
-#define EPD_CS      9
-#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
-#define SRAM_CS     6
-#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
-#define EPD_SPI     &SPI // primary SPI
+#define EPD_DC 10
+#define EPD_CS 9
+#define EPD_BUSY 7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS 6
+#define EPD_RESET 8  // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI &SPI // primary SPI
 #endif
 
 // 1.54" Monochrome displays with 200x200 pixels and SSD1681 chipset
-//ThinkInk_154_Mono_D67 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+// ThinkInk_154_Mono_D67 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 // 1.54" Monochrome displays with 200x200 pixels and SSD1608 chipset
-//ThinkInk_154_Mono_D27 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+// ThinkInk_154_Mono_D27 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 // 1.54" Monochrome displays with 152x152 pixels and UC8151D chipset
-//ThinkInk_154_Mono_M10 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
-
+// ThinkInk_154_Mono_M10 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 // 2.13" Monochrome displays with 250x122 pixels and SSD1675 chipset
 ThinkInk_213_Mono_B72 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 // 2.13" Monochrome displays with 250x122 pixels and SSD1675B chipset
-//ThinkInk_213_Mono_B73 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+// ThinkInk_213_Mono_B73 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 // 2.13" Monochrome displays with 250x122 pixels and SSD1680 chipset
-//ThinkInk_213_Mono_BN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
-//ThinkInk_213_Mono_B74 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+// ThinkInk_213_Mono_BN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+// ThinkInk_213_Mono_B74 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 // 2.13" Monochrome displays with 212x104 pixels and UC8151D chipset
-//ThinkInk_213_Mono_M21 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+// ThinkInk_213_Mono_M21 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
-
-// 2.9" 4-level Grayscale (use mono) displays with 296x128 pixels and IL0373 chipset
-//ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+// 2.9" 4-level Grayscale (use mono) displays with 296x128 pixels and IL0373
+// chipset
+// ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY);
 
 // 2.9" Monochrome displays with 296x128 pixels and UC8151D chipset
-//ThinkInk_290_Mono_M06 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
-
+// ThinkInk_290_Mono_M06 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 // 4.2" Monochrome displays with 400x300 pixels and SSD1619 chipset
-//ThinkInk_420_Mono_BN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+// ThinkInk_420_Mono_BN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 // 4.2" Monochrome displays with 400x300 pixels and UC8276 chipset
-//ThinkInk_420_Mono_M06 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
-
+// ThinkInk_420_Mono_M06 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 
 void setup() {
   Serial.begin(115200);
-  while (!Serial) { delay(10); }
+  while (!Serial) {
+    delay(10);
+  }
   Serial.println("Adafruit EPD full update test in mono");
   display.begin(THINKINK_MONO);
 }
@@ -74,42 +75,49 @@ void loop() {
   Serial.println("Banner demo");
   display.clearBuffer();
   display.setTextSize(3);
-  display.setCursor((display.width() - 180)/2, (display.height() - 24)/2);
+  display.setCursor((display.width() - 180) / 2, (display.height() - 24) / 2);
   display.setTextColor(EPD_BLACK);
   display.print("Monochrome");
   display.display();
 
   delay(2000);
-  
+
   Serial.println("B/W rectangle demo");
   display.clearBuffer();
-  display.fillRect(display.width()/2, 0, display.width()/2, display.height(), EPD_BLACK);
+  display.fillRect(display.width() / 2, 0, display.width() / 2,
+                   display.height(), EPD_BLACK);
   display.display();
 
   delay(2000);
-  
+
   Serial.println("Text demo");
   // large block of text
   display.clearBuffer();
   display.setTextSize(1);
-  testdrawtext("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a tortor imperdiet posuere. ", EPD_BLACK);
+  testdrawtext(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur "
+      "adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, "
+      "fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor "
+      "neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet "
+      "ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a "
+      "tortor imperdiet posuere. ",
+      EPD_BLACK);
   display.display();
 
   delay(2000);
 
   display.clearBuffer();
-  for (int16_t i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, EPD_BLACK);
+  for (int16_t i = 0; i < display.width(); i += 4) {
+    display.drawLine(0, 0, i, display.height() - 1, EPD_BLACK);
   }
 
-  for (int16_t i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, EPD_BLACK);
+  for (int16_t i = 0; i < display.height(); i += 4) {
+    display.drawLine(display.width() - 1, 0, 0, i, EPD_BLACK);
   }
   display.display();
 
-  delay(2000);  
+  delay(2000);
 }
-
 
 void testdrawtext(const char *text, uint16_t color) {
   display.setCursor(0, 0);

--- a/examples/ThinkInk_partial/ThinkInk_partial.ino
+++ b/examples/ThinkInk_partial/ThinkInk_partial.ino
@@ -9,11 +9,21 @@
 
 #include "Adafruit_ThinkInk.h"
 
-#define EPD_CS      9
+#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
+#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
+#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
+#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
+#define SRAM_CS     -1  // use onboard RAM
+#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
+#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#else
 #define EPD_DC      10
+#define EPD_CS      9
+#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
 #define SRAM_CS     6
 #define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
-#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define EPD_SPI     &SPI // primary SPI
+#endif
 
 //ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
 ThinkInk_154_Mono_D67 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/ThinkInk_partial/ThinkInk_partial.ino
+++ b/examples/ThinkInk_partial/ThinkInk_partial.ino
@@ -25,8 +25,8 @@
 #define EPD_SPI     &SPI // primary SPI
 #endif
 
-//ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
-ThinkInk_154_Mono_D67 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+ThinkInk_154_Mono_D67 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 void setup() {
   Serial.begin(115200);

--- a/examples/ThinkInk_partial/ThinkInk_partial.ino
+++ b/examples/ThinkInk_partial/ThinkInk_partial.ino
@@ -9,28 +9,33 @@
 
 #include "Adafruit_ThinkInk.h"
 
-#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
-#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
-#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
-#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
-#define SRAM_CS     -1  // use onboard RAM
-#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
-#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#ifdef ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK // detects if compiling for
+                                                // Feather RP2040 ThinkInk
+#define EPD_DC PIN_EPD_DC       // ThinkInk 24-pin connector DC
+#define EPD_CS PIN_EPD_CS       // ThinkInk 24-pin connector CS
+#define EPD_BUSY PIN_EPD_BUSY   // ThinkInk 24-pin connector Busy
+#define SRAM_CS -1              // use onboard RAM
+#define EPD_RESET PIN_EPD_RESET // ThinkInk 24-pin connector Reset
+#define EPD_SPI &SPI1           // secondary SPI for ThinkInk
 #else
-#define EPD_DC      10
-#define EPD_CS      9
-#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
-#define SRAM_CS     6
-#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
-#define EPD_SPI     &SPI // primary SPI
+#define EPD_DC 10
+#define EPD_CS 9
+#define EPD_BUSY 7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS 6
+#define EPD_RESET 8  // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI &SPI // primary SPI
 #endif
 
-//ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-ThinkInk_154_Mono_D67 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_290_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
+ThinkInk_154_Mono_D67 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
+                              EPD_SPI);
 
 void setup() {
   Serial.begin(115200);
-  while (!Serial) { delay(10); }
+  while (!Serial) {
+    delay(10);
+  }
   Serial.println("Adafruit counter");
   display.begin(THINKINK_MONO);
   display.setRotation(0);
@@ -52,15 +57,15 @@ void loop() {
     display.display(false);
   } else {
     // redraw only 4th digit
-    display.displayPartial(32+(24*3), 32, 32+(24*4), 32+(4*8));
+    display.displayPartial(32 + (24 * 3), 32, 32 + (24 * 4), 32 + (4 * 8));
   }
 
   counter++;
-/*
-  display.fillRect(0, 0, 16, 32, EPD_BLACK);
-  display.fillRect(4, 4, 8, 24, EPD_WHITE);
- //  display.display();
-  display.displayPartial(0, 0, 16, 32);
-  delay(3000);
-  */
+  /*
+    display.fillRect(0, 0, 16, 32, EPD_BLACK);
+    display.fillRect(4, 4, 8, 24, EPD_WHITE);
+   //  display.display();
+    display.displayPartial(0, 0, 16, 32);
+    delay(3000);
+    */
 }

--- a/examples/ThinkInk_tricolor/ThinkInk_tricolor.ino
+++ b/examples/ThinkInk_tricolor/ThinkInk_tricolor.ino
@@ -9,57 +9,71 @@
 
 #include "Adafruit_ThinkInk.h"
 
-#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
-#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
-#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
-#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
-#define SRAM_CS     -1  // use onboard RAM
-#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
-#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#ifdef ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK // detects if compiling for
+                                                // Feather RP2040 ThinkInk
+#define EPD_DC PIN_EPD_DC       // ThinkInk 24-pin connector DC
+#define EPD_CS PIN_EPD_CS       // ThinkInk 24-pin connector CS
+#define EPD_BUSY PIN_EPD_BUSY   // ThinkInk 24-pin connector Busy
+#define SRAM_CS -1              // use onboard RAM
+#define EPD_RESET PIN_EPD_RESET // ThinkInk 24-pin connector Reset
+#define EPD_SPI &SPI1           // secondary SPI for ThinkInk
 #else
-#define EPD_DC      10
-#define EPD_CS      9
-#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
-#define SRAM_CS     6
-#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
-#define EPD_SPI     &SPI // primary SPI
+#define EPD_DC 10
+#define EPD_CS 9
+#define EPD_BUSY 7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS 6
+#define EPD_RESET 8  // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI &SPI // primary SPI
 #endif
 
 // 1.54" 152x152 Tricolor EPD with ILI0373 chipset
-//ThinkInk_154_Tricolor_Z17 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_154_Tricolor_Z17 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // 1.54" 152x152 Tricolor EPD with SSD1680 chipset
-//ThinkInk_154_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_154_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // 1.54" 200x200 Tricolor EPD with SSD1681 chipset
-//ThinkInk_154_Tricolor_Z90 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_154_Tricolor_Z90 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // 2.13" Tricolor EPD with SSD1680 chipset
-ThinkInk_213_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+ThinkInk_213_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
+                                 EPD_SPI);
 
 // 2.13" Tricolor EPD with IL0373 chipset
-//ThinkInk_213_Tricolor_Z16 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_213_Tricolor_Z16 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // 2.7" Tricolor Featherwing or Breakout with IL91874 chipset
-//ThinkInk_270_Tricolor_C44 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_270_Tricolor_C44 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // 2.7" Tricolor Featherwing or Breakout with EK79686 chipset
-//ThinkInk_270_Tricolor_Z70 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_270_Tricolor_Z70 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 // 2.9" Tricolor Featherwing or Breakout with IL0373 chipset
-//ThinkInk_290_Tricolor_Z10 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_290_Tricolor_Z10 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 // 2.9" Tricolor Featherwing or Breakout with UC8151D chipset
-//ThinkInk_290_Tricolor_Z13 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-// 2.9" Tricolor Featherwing or Breakout with SSD1680 chipset and negative offset
-//ThinkInk_290_Tricolor_Z94 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// ThinkInk_290_Tricolor_Z13 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
+// 2.9" Tricolor Featherwing or Breakout with SSD1680 chipset and negative
+// offset
+// ThinkInk_290_Tricolor_Z94 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
-//ThinkInk_420_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-//ThinkInk_420_Tricolor_Z21 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-
+// ThinkInk_420_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI); ThinkInk_420_Tricolor_Z21 display(EPD_DC, EPD_RESET,
+// EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 void setup() {
   Serial.begin(115200);
-  while (!Serial) { delay(10); }
+  while (!Serial) {
+    delay(10);
+  }
   Serial.println("Adafruit EPD full update test in red/black/white");
   display.begin(THINKINK_TRICOLOR);
 }
@@ -68,45 +82,53 @@ void loop() {
   Serial.println("Banner demo");
   display.clearBuffer();
   display.setTextSize(3);
-  display.setCursor((display.width() - 144)/2, (display.height() - 24)/2);
+  display.setCursor((display.width() - 144) / 2, (display.height() - 24) / 2);
   display.setTextColor(EPD_BLACK);
-  display.print("Tri");  
+  display.print("Tri");
   display.setTextColor(EPD_RED);
-  display.print("Color");  
+  display.print("Color");
   display.display();
 
   delay(15000);
-  
+
   Serial.println("Color rectangle demo");
   display.clearBuffer();
-  display.fillRect(display.width()/3, 0, display.width()/3, display.height(), EPD_BLACK);
-  display.fillRect((display.width()*2)/3, 0, display.width()/3, display.height(), EPD_RED);
+  display.fillRect(display.width() / 3, 0, display.width() / 3,
+                   display.height(), EPD_BLACK);
+  display.fillRect((display.width() * 2) / 3, 0, display.width() / 3,
+                   display.height(), EPD_RED);
   display.display();
 
   delay(15000);
-  
+
   Serial.println("Text demo");
   // large block of text
   display.clearBuffer();
   display.setTextSize(1);
-  testdrawtext("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a tortor imperdiet posuere. ", EPD_BLACK);
+  testdrawtext(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur "
+      "adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, "
+      "fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor "
+      "neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet "
+      "ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a "
+      "tortor imperdiet posuere. ",
+      EPD_BLACK);
   display.display();
 
   delay(15000);
 
   display.clearBuffer();
-  for (int16_t i=0; i<display.width(); i+=4) {
-    display.drawLine(0, 0, i, display.height()-1, EPD_BLACK);
+  for (int16_t i = 0; i < display.width(); i += 4) {
+    display.drawLine(0, 0, i, display.height() - 1, EPD_BLACK);
   }
 
-  for (int16_t i=0; i<display.height(); i+=4) {
-    display.drawLine(display.width()-1, 0, 0, i, EPD_RED);
+  for (int16_t i = 0; i < display.height(); i += 4) {
+    display.drawLine(display.width() - 1, 0, 0, i, EPD_RED);
   }
   display.display();
 
-  delay(15000);  
+  delay(15000);
 }
-
 
 void testdrawtext(const char *text, uint16_t color) {
   display.setCursor(0, 0);

--- a/examples/ThinkInk_tricolor/ThinkInk_tricolor.ino
+++ b/examples/ThinkInk_tricolor/ThinkInk_tricolor.ino
@@ -9,42 +9,52 @@
 
 #include "Adafruit_ThinkInk.h"
 
-#define EPD_DC      10 // can be any pin, but required!
-#define EPD_CS      9  // can be any pin, but required!
-#define EPD_BUSY    7  // can set to -1 to not use a pin (will wait a fixed delay)
-#define SRAM_CS     6  // can set to -1 to not use a pin (uses a lot of RAM!)
-#define EPD_RESET   8  // can set to -1 and share with chip Reset (can't deep sleep)
+#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
+#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
+#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
+#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
+#define SRAM_CS     -1  // use onboard RAM
+#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
+#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#else
+#define EPD_DC      10
+#define EPD_CS      9
+#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS     6
+#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI     &SPI // primary SPI
+#endif
 
 // 1.54" 152x152 Tricolor EPD with ILI0373 chipset
-//ThinkInk_154_Tricolor_Z17 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_154_Tricolor_Z17 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // 1.54" 152x152 Tricolor EPD with SSD1680 chipset
-//ThinkInk_154_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_154_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // 1.54" 200x200 Tricolor EPD with SSD1681 chipset
-//ThinkInk_154_Tricolor_Z90 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_154_Tricolor_Z90 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // 2.13" Tricolor EPD with SSD1680 chipset
-//ThinkInk_213_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+ThinkInk_213_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // 2.13" Tricolor EPD with IL0373 chipset
-//ThinkInk_213_Tricolor_Z16 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_213_Tricolor_Z16 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // 2.7" Tricolor Featherwing or Breakout with IL91874 chipset
-//ThinkInk_270_Tricolor_C44 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_270_Tricolor_C44 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // 2.7" Tricolor Featherwing or Breakout with EK79686 chipset
-//ThinkInk_270_Tricolor_Z70 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_270_Tricolor_Z70 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 // 2.9" Tricolor Featherwing or Breakout with IL0373 chipset
-ThinkInk_290_Tricolor_Z10 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_290_Tricolor_Z10 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 // 2.9" Tricolor Featherwing or Breakout with UC8151D chipset
-//ThinkInk_290_Tricolor_Z13 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_290_Tricolor_Z13 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 // 2.9" Tricolor Featherwing or Breakout with SSD1680 chipset and negative offset
-//ThinkInk_290_Tricolor_Z94 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_290_Tricolor_Z94 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
-//ThinkInk_420_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
-//ThinkInk_420_Tricolor_Z21 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//ThinkInk_420_Tricolor_RW display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+//ThinkInk_420_Tricolor_Z21 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 
 void setup() {

--- a/examples/acep_7ColorTest/acep_7ColorTest.ino
+++ b/examples/acep_7ColorTest/acep_7ColorTest.ino
@@ -29,7 +29,7 @@
 #endif
 
 // Uncomment the following line if you are using ACeP 7 color 5.65"
-Adafruit_ACEP display(600, 448, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+Adafruit_ACEP display(600, 448, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,  EPD_SPI);
 
 Adafruit_FlashTransport_QSPI flashTransport;
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/acep_7ColorTest/acep_7ColorTest.ino
+++ b/examples/acep_7ColorTest/acep_7ColorTest.ino
@@ -7,29 +7,31 @@
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
+#include "Adafruit_EPD.h"
+#include <Adafruit_SPIFlash.h>
 #include <SPI.h>
 #include <SdFat.h>
-#include <Adafruit_SPIFlash.h>
-#include "Adafruit_EPD.h"
 
-#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
-#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
-#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
-#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
-#define SRAM_CS     -1  // use onboard RAM
-#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
-#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#ifdef ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK // detects if compiling for
+                                                // Feather RP2040 ThinkInk
+#define EPD_DC PIN_EPD_DC       // ThinkInk 24-pin connector DC
+#define EPD_CS PIN_EPD_CS       // ThinkInk 24-pin connector CS
+#define EPD_BUSY PIN_EPD_BUSY   // ThinkInk 24-pin connector Busy
+#define SRAM_CS -1              // use onboard RAM
+#define EPD_RESET PIN_EPD_RESET // ThinkInk 24-pin connector Reset
+#define EPD_SPI &SPI1           // secondary SPI for ThinkInk
 #else
-#define EPD_CS      9
-#define EPD_DC      10
-#define SRAM_CS     -1  // Use the build in memory, we need 133KB!
-#define EPD_RESET   6 // can set to -1 and share with microcontroller Reset!
-#define EPD_BUSY    5 // can set to -1 to not use a pin (will wait a fixed delay)
-#define EPD_SPI     &SPI // primary SPI
+#define EPD_CS 9
+#define EPD_DC 10
+#define SRAM_CS -1   // Use the build in memory, we need 133KB!
+#define EPD_RESET 6  // can set to -1 and share with microcontroller Reset!
+#define EPD_BUSY 5   // can set to -1 to not use a pin (will wait a fixed delay)
+#define EPD_SPI &SPI // primary SPI
 #endif
 
 // Uncomment the following line if you are using ACeP 7 color 5.65"
-Adafruit_ACEP display(600, 448, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,  EPD_SPI);
+Adafruit_ACEP display(600, 448, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
+                      EPD_SPI);
 
 Adafruit_FlashTransport_QSPI flashTransport;
 Adafruit_SPIFlash flash(&flashTransport);
@@ -37,32 +39,39 @@ FatFileSystem fatfs;
 
 void setup() {
   Serial.begin(115200);
-  while (!Serial) { delay(10); }
-    
-  Serial.println("Adafruit ACeP EPD test");  
-  
+  while (!Serial) {
+    delay(10);
+  }
+
+  Serial.println("Adafruit ACeP EPD test");
+
   if (!flash.begin()) {
     Serial.println("Error, failed to initialize flash chip!");
-    while(1) delay(1);
+    while (1)
+      delay(1);
   }
-  Serial.print("Flash chip JEDEC ID: 0x"); Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash chip JEDEC ID: 0x");
+  Serial.println(flash.getJEDECID(), HEX);
   // First call begin to mount the filesystem.  Check that it returns true
   // to make sure the filesystem was mounted.
   if (!fatfs.begin(&flash)) {
     Serial.println("Error, failed to mount newly formatted filesystem!");
-    Serial.println("Was the flash chip formatted with the fatfs_format example?");
-    while(1) delay(1);
+    Serial.println(
+        "Was the flash chip formatted with the fatfs_format example?");
+    while (1)
+      delay(1);
   }
   Serial.println("Mounted filesystem!");
   File root = fatfs.open("/");
   printDirectory(root, 0);
-  
+
   display.begin();
   display.setRotation(0);
   display.clearBuffer();
   // draw 7 color bars
-  for (uint8_t color=ACEP_COLOR_BLACK; color<=ACEP_COLOR_ORANGE; color++) {
-    display.fillRect(display.width()*color/7, 0, display.width()/7, display.height(), color);
+  for (uint8_t color = ACEP_COLOR_BLACK; color <= ACEP_COLOR_ORANGE; color++) {
+    display.fillRect(display.width() * color / 7, 0, display.width() / 7,
+                     display.height(), color);
   }
   display.display();
 }
@@ -70,14 +79,7 @@ void setup() {
 void loop() {
   bmpDraw("adafruit_characters.bmp", 0, 0);
   bmpDraw("adabot.bmp", 0, 0);
-
 }
-
-
-
-
-
-
 
 // This function opens a Windows Bitmap (BMP) file and
 // displays it at the given coordinates.  It's sped up
@@ -90,20 +92,21 @@ void loop() {
 #define BUFFPIXEL 20
 
 bool bmpDraw(const char *filename, int16_t x, int16_t y) {
-  File     bmpFile;
-  int      bmpWidth, bmpHeight;   // W+H in pixels
-  uint8_t  bmpDepth;              // Bit depth (currently must be 24)
-  uint32_t bmpImageoffset;        // Start of image data in file
-  uint32_t rowSize;               // Not always = bmpWidth; may have padding
-  uint8_t  sdbuffer[3*BUFFPIXEL]; // pixel buffer (R+G+B per pixel)
-  uint8_t  buffidx = sizeof(sdbuffer); // Current position in sdbuffer
-  boolean  goodBmp = false;       // Set to true on valid header parse
-  boolean  flip    = true;        // BMP is stored bottom-to-top
-  int      w, h, row, col, x2, y2, bx1, by1;
-  uint8_t  r, g, b;
+  File bmpFile;
+  int bmpWidth, bmpHeight;            // W+H in pixels
+  uint8_t bmpDepth;                   // Bit depth (currently must be 24)
+  uint32_t bmpImageoffset;            // Start of image data in file
+  uint32_t rowSize;                   // Not always = bmpWidth; may have padding
+  uint8_t sdbuffer[3 * BUFFPIXEL];    // pixel buffer (R+G+B per pixel)
+  uint8_t buffidx = sizeof(sdbuffer); // Current position in sdbuffer
+  boolean goodBmp = false;            // Set to true on valid header parse
+  boolean flip = true;                // BMP is stored bottom-to-top
+  int w, h, row, col, x2, y2, bx1, by1;
+  uint8_t r, g, b;
   uint32_t pos = 0, startTime = millis();
 
-  if((x >= display.width()) || (y >= display.height())) return false;
+  if ((x >= display.width()) || (y >= display.height()))
+    return false;
 
   Serial.println();
   Serial.print(F("Loading image '"));
@@ -118,18 +121,22 @@ bool bmpDraw(const char *filename, int16_t x, int16_t y) {
 
   // Parse BMP header
   if (read16(bmpFile) == 0x4D42) { // BMP signature
-    Serial.print(F("File size: ")); Serial.println(read32(bmpFile));
-    (void)read32(bmpFile); // Read & ignore creator bytes
+    Serial.print(F("File size: "));
+    Serial.println(read32(bmpFile));
+    (void)read32(bmpFile);            // Read & ignore creator bytes
     bmpImageoffset = read32(bmpFile); // Start of image data
-    Serial.print(F("Image Offset: ")); Serial.println(bmpImageoffset, DEC);
+    Serial.print(F("Image Offset: "));
+    Serial.println(bmpImageoffset, DEC);
     // Read DIB header
-    Serial.print(F("Header size: ")); Serial.println(read32(bmpFile));
-    bmpWidth  = read32(bmpFile);
+    Serial.print(F("Header size: "));
+    Serial.println(read32(bmpFile));
+    bmpWidth = read32(bmpFile);
     bmpHeight = read32(bmpFile);
-    if(read16(bmpFile) == 1) { // # planes -- must be '1'
+    if (read16(bmpFile) == 1) {   // # planes -- must be '1'
       bmpDepth = read16(bmpFile); // bits per pixel
-      Serial.print(F("Bit Depth: ")); Serial.println(bmpDepth);
-      if((bmpDepth == 24) && (read32(bmpFile) == 0)) { // 0 = uncompressed
+      Serial.print(F("Bit Depth: "));
+      Serial.println(bmpDepth);
+      if ((bmpDepth == 24) && (read32(bmpFile) == 0)) { // 0 = uncompressed
 
         goodBmp = true; // Supported BMP format -- proceed!
         Serial.print(F("Image size: "));
@@ -142,37 +149,37 @@ bool bmpDraw(const char *filename, int16_t x, int16_t y) {
 
         // If bmpHeight is negative, image is in top-down order.
         // This is not canon but has been observed in the wild.
-        if(bmpHeight < 0) {
+        if (bmpHeight < 0) {
           bmpHeight = -bmpHeight;
-          flip      = false;
+          flip = false;
         }
 
         // Crop area to be loaded
-        x2 = x + bmpWidth  - 1; // Lower-right corner
+        x2 = x + bmpWidth - 1; // Lower-right corner
         y2 = y + bmpHeight - 1;
-        if((x2 >= 0) && (y2 >= 0)) { // On screen?
-          w = bmpWidth; // Width/height of section to load/display
+        if ((x2 >= 0) && (y2 >= 0)) { // On screen?
+          w = bmpWidth;               // Width/height of section to load/display
           h = bmpHeight;
           bx1 = by1 = 0; // UL coordinate in BMP file
-  
-          for (row=0; row<h; row++) { // For each scanline...
-  
+
+          for (row = 0; row < h; row++) { // For each scanline...
+
             // Seek to start of scan line.  It might seem labor-
             // intensive to be doing this on every line, but this
             // method covers a lot of gritty details like cropping
             // and scanline padding.  Also, the seek only takes
             // place if the file position actually needs to change
             // (avoids a lot of cluster math in SD library).
-            if(flip) // Bitmap is stored bottom-to-top order (normal BMP)
+            if (flip) // Bitmap is stored bottom-to-top order (normal BMP)
               pos = bmpImageoffset + (bmpHeight - 1 - (row + by1)) * rowSize;
-            else     // Bitmap is stored top-to-bottom
+            else // Bitmap is stored top-to-bottom
               pos = bmpImageoffset + (row + by1) * rowSize;
-            pos += bx1 * 3; // Factor in starting column (bx1)
-            if(bmpFile.position() != pos) { // Need seek?
+            pos += bx1 * 3;                  // Factor in starting column (bx1)
+            if (bmpFile.position() != pos) { // Need seek?
               bmpFile.seek(pos);
               buffidx = sizeof(sdbuffer); // Force buffer reload
             }
-            for (col=0; col<w; col++) { // For each pixel...
+            for (col = 0; col < w; col++) { // For each pixel...
               // Time to read more pixel data?
               if (buffidx >= sizeof(sdbuffer)) { // Indeed
                 bmpFile.read(sdbuffer, sizeof(sdbuffer));
@@ -190,23 +197,37 @@ bool bmpDraw(const char *filename, int16_t x, int16_t y) {
 
               uint8_t c;
               switch (color) {
-                case 0x000000: c = ACEP_COLOR_BLACK; break;
-                case 0xFFFFFF: c = ACEP_COLOR_WHITE; break;
-                case 0x00FF00: c = ACEP_COLOR_GREEN; break;
-                case 0x0000FF: c = ACEP_COLOR_BLUE; break;
-                case 0xFF0000: c = ACEP_COLOR_RED; break;
-                case 0xFFFF00: c = ACEP_COLOR_YELLOW; break;
-                case 0xFF8000: c = ACEP_COLOR_ORANGE; break;
-                default: {
-                  Serial.print("Unknown color 0x"); 
-                  Serial.println(color, HEX);
-                  c = ACEP_COLOR_WHITE;
-                }
+              case 0x000000:
+                c = ACEP_COLOR_BLACK;
+                break;
+              case 0xFFFFFF:
+                c = ACEP_COLOR_WHITE;
+                break;
+              case 0x00FF00:
+                c = ACEP_COLOR_GREEN;
+                break;
+              case 0x0000FF:
+                c = ACEP_COLOR_BLUE;
+                break;
+              case 0xFF0000:
+                c = ACEP_COLOR_RED;
+                break;
+              case 0xFFFF00:
+                c = ACEP_COLOR_YELLOW;
+                break;
+              case 0xFF8000:
+                c = ACEP_COLOR_ORANGE;
+                break;
+              default: {
+                Serial.print("Unknown color 0x");
+                Serial.println(color, HEX);
+                c = ACEP_COLOR_WHITE;
+              }
               }
               display.writePixel(col, row, c);
             } // end pixel
-          } // end scanline
-        } // end onscreen
+          }   // end scanline
+        }     // end onscreen
         display.display();
         Serial.print(F("Loaded in "));
         Serial.print(millis() - startTime);
@@ -216,7 +237,7 @@ bool bmpDraw(const char *filename, int16_t x, int16_t y) {
   }
 
   bmpFile.close();
-  if(!goodBmp) {
+  if (!goodBmp) {
     Serial.println(F("BMP format not recognized."));
     return false;
   }
@@ -243,13 +264,12 @@ uint32_t read32(File &f) {
   return result;
 }
 
-
 void printDirectory(File dir, int numTabs) {
   char filename[80];
-  
+
   while (true) {
-    File entry =  dir.openNextFile();
-    if (! entry) {
+    File entry = dir.openNextFile();
+    if (!entry) {
       // no more files
       break;
     }

--- a/examples/acep_7ColorTest/acep_7ColorTest.ino
+++ b/examples/acep_7ColorTest/acep_7ColorTest.ino
@@ -7,18 +7,26 @@
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
-
 #include <SPI.h>
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 #include "Adafruit_EPD.h"
 
-
+#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
+#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
+#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
+#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
+#define SRAM_CS     -1  // use onboard RAM
+#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
+#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#else
 #define EPD_CS      9
 #define EPD_DC      10
 #define SRAM_CS     -1  // Use the build in memory, we need 133KB!
 #define EPD_RESET   6 // can set to -1 and share with microcontroller Reset!
 #define EPD_BUSY    5 // can set to -1 to not use a pin (will wait a fixed delay)
+#define EPD_SPI     &SPI // primary SPI
+#endif
 
 // Uncomment the following line if you are using ACeP 7 color 5.65"
 Adafruit_ACEP display(600, 448, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -7,48 +7,55 @@
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Adafruit_GFX.h>    // Core graphics library
 #include "Adafruit_EPD.h"
+#include <Adafruit_GFX.h> // Core graphics library
 
-#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
-#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
-#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
-#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
-#define SRAM_CS     -1  // use onboard RAM
-#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
-#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#ifdef ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK // detects if compiling for
+                                                // Feather RP2040 ThinkInk
+#define EPD_DC PIN_EPD_DC       // ThinkInk 24-pin connector DC
+#define EPD_CS PIN_EPD_CS       // ThinkInk 24-pin connector CS
+#define EPD_BUSY PIN_EPD_BUSY   // ThinkInk 24-pin connector Busy
+#define SRAM_CS -1              // use onboard RAM
+#define EPD_RESET PIN_EPD_RESET // ThinkInk 24-pin connector Reset
+#define EPD_SPI &SPI1           // secondary SPI for ThinkInk
 #else
-#define EPD_DC      10
-#define EPD_CS      9
-#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
-#define SRAM_CS     6
-#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
-#define EPD_SPI     &SPI // primary SPI
+#define EPD_DC 10
+#define EPD_CS 9
+#define EPD_BUSY 7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS 6
+#define EPD_RESET 8  // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI &SPI // primary SPI
 #endif
 
 /* Uncomment the following line if you are using 1.54" tricolor EPD */
-//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 1.54" monochrome EPD */
-//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.13" tricolor EPD */
-Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
+                        EPD_SPI);
 //#define FLEXIBLE_213
 
 /* Uncomment the following line if you are using 2.13" monochrome 250*122 EPD */
-//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
-/* Uncomment the following line if you are using 2.7" tricolor or grayscale EPD */
-//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+/* Uncomment the following line if you are using 2.7" tricolor or grayscale EPD
+ */
+// Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.9" EPD */
-//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-//#define FLEXIBLE_290
+// Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI); #define FLEXIBLE_290
 
 /* Uncomment the following line if you are using 4.2" tricolor EPD */
-//Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-
+// Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 float p = 3.1415926;
 
@@ -57,7 +64,7 @@ void setup(void) {
   Serial.print("Hello! EPD Test");
 
   display.begin();
-  
+
 #if defined(FLEXIBLE_213) || defined(FLEXIBLE_290)
   // The flexible displays have different buffers and invert settings!
   display.setBlackBuffer(1, false);
@@ -67,8 +74,10 @@ void setup(void) {
   Serial.println("Initialized");
 
   display.clearBuffer();
-  display.fillRect(display.width()/3, 0, display.width()/3, display.height(), EPD_RED);
-  display.fillRect((display.width()*2)/3, 0, display.width()/3, display.height(), EPD_BLACK);
+  display.fillRect(display.width() / 3, 0, display.width() / 3,
+                   display.height(), EPD_RED);
+  display.fillRect((display.width() * 2) / 3, 0, display.width() / 3,
+                   display.height(), EPD_BLACK);
   display.display();
 
   delay(15 * 1000);
@@ -76,7 +85,14 @@ void setup(void) {
   // large block of text
   display.clearBuffer();
   display.fillScreen(EPD_WHITE);
-  testdrawtext("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a tortor imperdiet posuere. ", EPD_BLACK);
+  testdrawtext(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur "
+      "adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa, "
+      "fringilla sed malesuada et, malesuada sit amet turpis. Sed porttitor "
+      "neque ut ante pretium vitae malesuada nunc bibendum. Nullam aliquet "
+      "ultrices massa eu hendrerit. Ut sed nisi lorem. In vestibulum purus a "
+      "tortor imperdiet posuere. ",
+      EPD_BLACK);
 
   delay(15 * 1000);
 
@@ -87,14 +103,14 @@ void setup(void) {
 
   // a single pixel
   display.clearBuffer();
-  display.drawPixel(display.width()/2, display.height()/2, EPD_BLACK);
+  display.drawPixel(display.width() / 2, display.height() / 2, EPD_BLACK);
 
   delay(15 * 1000);
 
   testtriangles();
 
   delay(15 * 1000);
-  
+
   // line draw test
   testlines(EPD_BLACK);
 
@@ -128,42 +144,40 @@ void setup(void) {
   Serial.println("done");
 }
 
-void loop() {
-  delay(500);
-}
+void loop() { delay(500); }
 
 void testlines(uint16_t color) {
   display.clearBuffer();
   display.fillScreen(EPD_WHITE);
-  for (int16_t x=0; x < display.width(); x+=6) {
-    display.drawLine(0, 0, x, display.height()-1, color);
+  for (int16_t x = 0; x < display.width(); x += 6) {
+    display.drawLine(0, 0, x, display.height() - 1, color);
   }
-  for (int16_t y=0; y < display.height(); y+=6) {
-    display.drawLine(0, 0, display.width()-1, y, color);
-  }
-
-  display.fillScreen(EPD_WHITE);
-  for (int16_t x=0; x < display.width(); x+=6) {
-    display.drawLine(display.width()-1, 0, x, display.height()-1, color);
-  }
-  for (int16_t y=0; y < display.height(); y+=6) {
-    display.drawLine(display.width()-1, 0, 0, y, color);
+  for (int16_t y = 0; y < display.height(); y += 6) {
+    display.drawLine(0, 0, display.width() - 1, y, color);
   }
 
   display.fillScreen(EPD_WHITE);
-  for (int16_t x=0; x < display.width(); x+=6) {
-    display.drawLine(0, display.height()-1, x, 0, color);
+  for (int16_t x = 0; x < display.width(); x += 6) {
+    display.drawLine(display.width() - 1, 0, x, display.height() - 1, color);
   }
-  for (int16_t y=0; y < display.height(); y+=6) {
-    display.drawLine(0, display.height()-1, display.width()-1, y, color);
+  for (int16_t y = 0; y < display.height(); y += 6) {
+    display.drawLine(display.width() - 1, 0, 0, y, color);
   }
 
   display.fillScreen(EPD_WHITE);
-  for (int16_t x=0; x < display.width(); x+=6) {
-    display.drawLine(display.width()-1, display.height()-1, x, 0, color);
+  for (int16_t x = 0; x < display.width(); x += 6) {
+    display.drawLine(0, display.height() - 1, x, 0, color);
   }
-  for (int16_t y=0; y < display.height(); y+=6) {
-    display.drawLine(display.width()-1, display.height()-1, 0, y, color);
+  for (int16_t y = 0; y < display.height(); y += 6) {
+    display.drawLine(0, display.height() - 1, display.width() - 1, y, color);
+  }
+
+  display.fillScreen(EPD_WHITE);
+  for (int16_t x = 0; x < display.width(); x += 6) {
+    display.drawLine(display.width() - 1, display.height() - 1, x, 0, color);
+  }
+  for (int16_t y = 0; y < display.height(); y += 6) {
+    display.drawLine(display.width() - 1, display.height() - 1, 0, y, color);
   }
   display.display();
 }
@@ -180,10 +194,10 @@ void testdrawtext(const char *text, uint16_t color) {
 void testfastlines(uint16_t color1, uint16_t color2) {
   display.clearBuffer();
   display.fillScreen(EPD_WHITE);
-  for (int16_t y=0; y < display.height(); y+=5) {
+  for (int16_t y = 0; y < display.height(); y += 5) {
     display.drawFastHLine(0, y, display.width(), color1);
   }
-  for (int16_t x=0; x < display.width(); x+=5) {
+  for (int16_t x = 0; x < display.width(); x += 5) {
     display.drawFastVLine(x, 0, display.height(), color2);
   }
   display.display();
@@ -192,8 +206,9 @@ void testfastlines(uint16_t color1, uint16_t color2) {
 void testdrawrects(uint16_t color) {
   display.clearBuffer();
   display.fillScreen(EPD_WHITE);
-  for (int16_t x=0; x < display.width(); x+=6) {
-    display.drawRect(display.width()/2 -x/2, display.height()/2 -x/2 , x, x, color);
+  for (int16_t x = 0; x < display.width(); x += 6) {
+    display.drawRect(display.width() / 2 - x / 2, display.height() / 2 - x / 2,
+                     x, x, color);
   }
   display.display();
 }
@@ -201,17 +216,19 @@ void testdrawrects(uint16_t color) {
 void testfillrects(uint16_t color1, uint16_t color2) {
   display.clearBuffer();
   display.fillScreen(EPD_WHITE);
-  for (int16_t x=display.width()-1; x > 6; x-=6) {
-    display.fillRect(display.width()/2 -x/2, display.height()/2 -x/2 , x, x, color1);
-    display.drawRect(display.width()/2 -x/2, display.height()/2 -x/2 , x, x, color2);
+  for (int16_t x = display.width() - 1; x > 6; x -= 6) {
+    display.fillRect(display.width() / 2 - x / 2, display.height() / 2 - x / 2,
+                     x, x, color1);
+    display.drawRect(display.width() / 2 - x / 2, display.height() / 2 - x / 2,
+                     x, x, color2);
   }
   display.display();
 }
 
 void testfillcircles(uint8_t radius, uint16_t color) {
   display.clearBuffer();
-  for (int16_t x=radius; x < display.width(); x+=radius*2) {
-    for (int16_t y=radius; y < display.height(); y+=radius*2) {
+  for (int16_t x = radius; x < display.width(); x += radius * 2) {
+    for (int16_t y = radius; y < display.height(); y += radius * 2) {
       display.fillCircle(x, y, radius, color);
     }
   }
@@ -220,8 +237,8 @@ void testfillcircles(uint8_t radius, uint16_t color) {
 
 void testdrawcircles(uint8_t radius, uint16_t color) {
   display.clearBuffer();
-  for (int16_t x=0; x < display.width()+radius; x+=radius*2) {
-    for (int16_t y=0; y < display.height()+radius; y+=radius*2) {
+  for (int16_t x = 0; x < display.width() + radius; x += radius * 2) {
+    for (int16_t y = 0; y < display.height() + radius; y += radius * 2) {
       display.drawCircle(x, y, radius, color);
     }
   }
@@ -233,16 +250,17 @@ void testtriangles() {
   display.fillScreen(EPD_WHITE);
   int color = EPD_BLACK;
   int t;
-  int w = display.width()/2;
-  int x = display.height()-1;
+  int w = display.width() / 2;
+  int x = display.height() - 1;
   int y = 0;
   int z = display.width();
-  for(t = 0 ; t <= 15; t++) {
+  for (t = 0; t <= 15; t++) {
     display.drawTriangle(w, y, y, x, z, x, color);
-    x-=4;
-    y+=4;
-    z-=4;
-    if(t == 8) color = EPD_RED;
+    x -= 4;
+    y += 4;
+    z -= 4;
+    if (t == 8)
+      color = EPD_RED;
   }
   display.display();
 }
@@ -253,18 +271,19 @@ void testroundrects() {
   int color = EPD_BLACK;
   int i;
   int t;
-  for(t = 0 ; t <= 4; t+=1) {
+  for (t = 0; t <= 4; t += 1) {
     int x = 0;
     int y = 0;
-    int w = display.width()-2;
-    int h = display.height()-2;
-    for(i = 0 ; i <= 16; i+=1) {
+    int w = display.width() - 2;
+    int h = display.height() - 2;
+    for (i = 0; i <= 16; i += 1) {
       display.drawRoundRect(x, y, w, h, 5, color);
-      x+=2;
-      y+=3;
-      w-=4;
-      h-=6;
-      if(i == 7) color = EPD_RED;
+      x += 2;
+      y += 3;
+      w -= 4;
+      h -= 6;
+      if (i == 7)
+        color = EPD_RED;
     }
     color = EPD_BLACK;
   }

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -27,27 +27,27 @@
 #endif
 
 /* Uncomment the following line if you are using 1.54" tricolor EPD */
-//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 1.54" monochrome EPD */
-//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.13" tricolor EPD */
-Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 //#define FLEXIBLE_213
 
 /* Uncomment the following line if you are using 2.13" monochrome 250*122 EPD */
-//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.7" tricolor or grayscale EPD */
-//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS);
+//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.9" EPD */
-//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 //#define FLEXIBLE_290
 
 /* Uncomment the following line if you are using 4.2" tricolor EPD */
-//Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 
 float p = 3.1415926;

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -10,11 +10,21 @@
 #include <Adafruit_GFX.h>    // Core graphics library
 #include "Adafruit_EPD.h"
 
-#define EPD_CS     10
-#define EPD_DC      9
-#define SRAM_CS     8
-#define EPD_RESET   5 // can set to -1 and share with microcontroller Reset!
-#define EPD_BUSY    3 // can set to -1 to not use a pin (will wait a fixed delay)
+#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
+#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
+#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
+#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
+#define SRAM_CS     -1  // use onboard RAM
+#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
+#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#else
+#define EPD_DC      10
+#define EPD_CS      9
+#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS     6
+#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI     &SPI // primary SPI
+#endif
 
 /* Uncomment the following line if you are using 1.54" tricolor EPD */
 //Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/rotation_test/rotation_test.ino
+++ b/examples/rotation_test/rotation_test.ino
@@ -7,56 +7,63 @@
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Adafruit_GFX.h>    // Core graphics library
 #include "Adafruit_EPD.h"
+#include <Adafruit_GFX.h> // Core graphics library
 
 // Default is FeatherWing pinouts
 
-#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
-#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
-#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
-#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
-#define SRAM_CS     -1  // use onboard RAM
-#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
-#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#ifdef ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK // detects if compiling for
+                                                // Feather RP2040 ThinkInk
+#define EPD_DC PIN_EPD_DC       // ThinkInk 24-pin connector DC
+#define EPD_CS PIN_EPD_CS       // ThinkInk 24-pin connector CS
+#define EPD_BUSY PIN_EPD_BUSY   // ThinkInk 24-pin connector Busy
+#define SRAM_CS -1              // use onboard RAM
+#define EPD_RESET PIN_EPD_RESET // ThinkInk 24-pin connector Reset
+#define EPD_SPI &SPI1           // secondary SPI for ThinkInk
 #else
-#define EPD_DC      10
-#define EPD_CS      9
-#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
-#define SRAM_CS     6
-#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
-#define EPD_SPI     &SPI // primary SPI
+#define EPD_DC 10
+#define EPD_CS 9
+#define EPD_BUSY 7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS 6
+#define EPD_RESET 8  // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI &SPI // primary SPI
 #endif
 
 /* Uncomment the following line if you are using 1.54" tricolor EPD */
-//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 1.54" monochrome EPD */
-//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.13" tricolor EPD */
-Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
+                        EPD_SPI);
 //#define FLEXIBLE_213
 
 /* Uncomment the following line if you are using 2.13" monochrome 250*122 EPD */
-//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
-/* Uncomment the following line if you are using 2.7" tricolor or grayscale EPD */
-//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+/* Uncomment the following line if you are using 2.7" tricolor or grayscale EPD
+ */
+// Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.9" EPD */
-//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-//#define FLEXIBLE_290
+// Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI); #define FLEXIBLE_290
 
 /* Uncomment the following line if you are using 4.2" tricolor EPD */
-//Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-
+// Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 void setup(void) {
   Serial.begin(115200);
   Serial.print("Hello! EPD Test");
 
-  display.begin();	
+  display.begin();
   Serial.println("Initialized");
 
 #if defined(FLEXIBLE_213) || defined(FLEXIBLE_290)
@@ -67,14 +74,14 @@ void setup(void) {
 }
 
 void loop() {
-  for (int rot=0; rot<4; rot++) {
+  for (int rot = 0; rot < 4; rot++) {
     display.setRotation(rot);
     display.clearBuffer();
     display.fillScreen(EPD_WHITE);
     display.drawRect(10, 20, 10, 20, EPD_BLACK);
-  
+
     display.display();
-  
+
     delay(1000);
   }
 }

--- a/examples/rotation_test/rotation_test.ino
+++ b/examples/rotation_test/rotation_test.ino
@@ -29,27 +29,27 @@
 #endif
 
 /* Uncomment the following line if you are using 1.54" tricolor EPD */
-//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 1.54" monochrome EPD */
-//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.13" tricolor EPD */
-Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 //#define FLEXIBLE_213
 
 /* Uncomment the following line if you are using 2.13" monochrome 250*122 EPD */
-//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.7" tricolor or grayscale EPD */
-//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS);
+//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.9" EPD */
-//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 //#define FLEXIBLE_290
 
 /* Uncomment the following line if you are using 4.2" tricolor EPD */
-//Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 
 void setup(void) {

--- a/examples/rotation_test/rotation_test.ino
+++ b/examples/rotation_test/rotation_test.ino
@@ -12,11 +12,21 @@
 
 // Default is FeatherWing pinouts
 
-#define EPD_CS     10
-#define EPD_DC      9
+#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
+#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
+#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
+#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
+#define SRAM_CS     -1  // use onboard RAM
+#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
+#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#else
+#define EPD_DC      10
+#define EPD_CS      9
+#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
 #define SRAM_CS     6
-#define EPD_RESET   4 // can set to -1 and share with microcontroller Reset!
-#define EPD_BUSY    -1 // can set to -1 to not use a pin (will wait a fixed delay)
+#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI     &SPI // primary SPI
+#endif
 
 /* Uncomment the following line if you are using 1.54" tricolor EPD */
 //Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/text_test/text_test.ino
+++ b/examples/text_test/text_test.ino
@@ -27,27 +27,27 @@
 #endif
 
 /* Uncomment the following line if you are using 1.54" tricolor EPD */
-//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 1.54" monochrome EPD */
-//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.13" tricolor EPD */
-Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 //#define FLEXIBLE_213
 
 /* Uncomment the following line if you are using 2.13" monochrome 250*122 EPD */
-//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.7" tricolor or grayscale EPD */
-//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS);
+//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.9" EPD */
-//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 //#define FLEXIBLE_290
 
 /* Uncomment the following line if you are using 4.2" tricolor EPD */
-//Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);
+//Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 void setup(void) {
   Serial.begin(115200);

--- a/examples/text_test/text_test.ino
+++ b/examples/text_test/text_test.ino
@@ -10,11 +10,21 @@
 #include <Adafruit_GFX.h>    // Core graphics library
 #include "Adafruit_EPD.h"
 
-#define EPD_CS     10
-#define EPD_DC      9
+#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
+#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
+#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
+#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
+#define SRAM_CS     -1  // use onboard RAM
+#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
+#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#else
+#define EPD_DC      10
+#define EPD_CS      9
+#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
 #define SRAM_CS     6
-#define EPD_RESET   5 // can set to -1 and share with microcontroller Reset!
-#define EPD_BUSY    -1 // can set to -1 to not use a pin (will wait a fixed delay)
+#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI     &SPI // primary SPI
+#endif
 
 /* Uncomment the following line if you are using 1.54" tricolor EPD */
 //Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY);

--- a/examples/text_test/text_test.ino
+++ b/examples/text_test/text_test.ino
@@ -7,47 +7,55 @@
   MIT license, all text above must be included in any redistribution
  ****************************************************/
 
-#include <Adafruit_GFX.h>    // Core graphics library
 #include "Adafruit_EPD.h"
+#include <Adafruit_GFX.h> // Core graphics library
 
-#ifdef PIN_EPD_MOSI // detects if compiling for Feather RP2040 ThinkInk
-#define EPD_DC      PIN_EPD_DC // ThinkInk 24-pin connector DC
-#define EPD_CS      PIN_EPD_CS  // ThinkInk 24-pin connector CS
-#define EPD_BUSY    PIN_EPD_BUSY  // ThinkInk 24-pin connector Busy
-#define SRAM_CS     -1  // use onboard RAM
-#define EPD_RESET   PIN_EPD_RESET  // ThinkInk 24-pin connector Reset
-#define EPD_SPI     &SPI1 // secondary SPI for ThinkInk
+#ifdef ARDUINO_ADAFRUIT_FEATHER_RP2040_THINKINK // detects if compiling for
+                                                // Feather RP2040 ThinkInk
+#define EPD_DC PIN_EPD_DC       // ThinkInk 24-pin connector DC
+#define EPD_CS PIN_EPD_CS       // ThinkInk 24-pin connector CS
+#define EPD_BUSY PIN_EPD_BUSY   // ThinkInk 24-pin connector Busy
+#define SRAM_CS -1              // use onboard RAM
+#define EPD_RESET PIN_EPD_RESET // ThinkInk 24-pin connector Reset
+#define EPD_SPI &SPI1           // secondary SPI for ThinkInk
 #else
-#define EPD_DC      10
-#define EPD_CS      9
-#define EPD_BUSY    7 // can set to -1 to not use a pin (will wait a fixed delay)
-#define SRAM_CS     6
-#define EPD_RESET   8 // can set to -1 and share with microcontroller Reset!
-#define EPD_SPI     &SPI // primary SPI
+#define EPD_DC 10
+#define EPD_CS 9
+#define EPD_BUSY 7 // can set to -1 to not use a pin (will wait a fixed delay)
+#define SRAM_CS 6
+#define EPD_RESET 8  // can set to -1 and share with microcontroller Reset!
+#define EPD_SPI &SPI // primary SPI
 #endif
 
 /* Uncomment the following line if you are using 1.54" tricolor EPD */
-//Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_IL0373 display(152, 152, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 1.54" monochrome EPD */
-//Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1608 display(200, 200, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.13" tricolor EPD */
-Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+Adafruit_IL0373 display(212, 104, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
+                        EPD_SPI);
 //#define FLEXIBLE_213
 
 /* Uncomment the following line if you are using 2.13" monochrome 250*122 EPD */
-//Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_SSD1675 display(250, 122, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
-/* Uncomment the following line if you are using 2.7" tricolor or grayscale EPD */
-//Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+/* Uncomment the following line if you are using 2.7" tricolor or grayscale EPD
+ */
+// Adafruit_IL91874 display(264, 176, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 /* Uncomment the following line if you are using 2.9" EPD */
-//Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
-//#define FLEXIBLE_290
+// Adafruit_IL0373 display(296, 128, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI); #define FLEXIBLE_290
 
 /* Uncomment the following line if you are using 4.2" tricolor EPD */
-//Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// Adafruit_IL0398 display(300, 400, EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI);
 
 void setup(void) {
   Serial.begin(115200);
@@ -71,7 +79,8 @@ void setup(void) {
   display.setCursor(10, 10);
   display.setTextSize(1);
   display.setTextColor(EPD_BLACK);
-  display.print("Get as much education as you can. Nobody can take that away from you");
+  display.print(
+      "Get as much education as you can. Nobody can take that away from you");
 
   display.setCursor(50, 70);
   display.setTextColor(EPD_RED);
@@ -80,6 +89,4 @@ void setup(void) {
   display.display();
 }
 
-void loop() {
-  delay(500);
-}
+void loop() { delay(500); }


### PR DESCRIPTION
Adding `ifdef` detection for Feather RP2040 ThinkInk to use 24 pin connector pins and `SPI1`. Tested with hardware