### PR TITLE
Remove volatile compound assignments and add cast for min

### DIFF
--- a/src/Adafruit_EPD.cpp
+++ b/src/Adafruit_EPD.cpp
@@ -656,7 +656,7 @@ uint8_t Adafruit_EPD::SPItransfer(uint8_t d) {
 void Adafruit_EPD::csHigh() {
 
 #ifdef BUSIO_USE_FAST_PINIO
-  *csPort |= csPinMask;
+  *csPort = *csPort | csPinMask;
 #else
   digitalWrite(_cs_pin, HIGH);
 #endif
@@ -680,7 +680,7 @@ void Adafruit_EPD::csLow() {
   }
 
 #ifdef BUSIO_USE_FAST_PINIO
-  *csPort &= ~csPinMask;
+  *csPort = *csPort & ~csPinMask;
 #else
   digitalWrite(_cs_pin, LOW);
 #endif
@@ -693,7 +693,7 @@ void Adafruit_EPD::csLow() {
 /**************************************************************************/
 void Adafruit_EPD::dcHigh() {
 #ifdef BUSIO_USE_FAST_PINIO
-  *dcPort |= dcPinMask;
+  *dcPort = *dcPort | dcPinMask;
 #else
   digitalWrite(_dc_pin, HIGH);
 #endif
@@ -706,7 +706,7 @@ void Adafruit_EPD::dcHigh() {
 /**************************************************************************/
 void Adafruit_EPD::dcLow() {
 #ifdef BUSIO_USE_FAST_PINIO
-  *dcPort &= ~dcPinMask;
+  *dcPort = *dcPort & ~dcPinMask;
 #else
   digitalWrite(_dc_pin, LOW);
 #endif

--- a/src/drivers/Adafruit_ACeP.cpp
+++ b/src/drivers/Adafruit_ACeP.cpp
@@ -129,7 +129,7 @@ void Adafruit_ACEP::deGhost() {
   uint32_t remaining = (600UL * 448UL / 2);
   while (remaining) {
     uint8_t block[256];
-    uint32_t numbytes = min(remaining, sizeof(block));
+    uint32_t numbytes = min(remaining, (uint32_t)sizeof(block));
     memset(block, 0x77, numbytes);
     EPD_data(block, numbytes);
     remaining -= numbytes;

--- a/src/drivers/Adafruit_UC8151D.cpp
+++ b/src/drivers/Adafruit_UC8151D.cpp
@@ -305,7 +305,7 @@ void Adafruit_UC8151D::displayPartial(uint16_t x1, uint16_t y1, uint16_t x2,
     uint32_t offset = 0;
     uint8_t mcp_buf[16];
     while (remaining) {
-      uint8_t to_xfer = min(sizeof(mcp_buf), remaining);
+      uint8_t to_xfer = min((uint32_t)sizeof(mcp_buf), remaining);
 
       sram.read(buffer2_addr + offset, mcp_buf, to_xfer);
       sram.write(buffer1_addr + offset, mcp_buf, to_xfer);


### PR DESCRIPTION
Removes use of compound assignments with volatiles to avoid compile warns. Example warn for ref:
```
  /home/runner/Arduino/libraries/Adafruit_EPD/src/Adafruit_EPD.cpp:659:11: warning: compound assignment with 'volatile'-qualified left operand is deprecated [-Wvolatile]
    659 |   *csPort |= csPinMask;
        |   ~~~~~~~~^~~~~~~~~~~~
```

Also adds an explicit cast to a `min` call that was causing a compile **error**:
```
  /home/runner/Arduino/libraries/Adafruit_EPD/src/drivers/Adafruit_ACeP.cpp:132:28: error: no matching function for call to 'min(uint32_t&, unsigned int)'
    132 |     uint32_t numbytes = min(remaining, sizeof(block));
        |                         ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
```