### PR TITLE
ThinkInk_213_Grayscale4_MFGN: add optional colstart

### DIFF
--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -55,6 +55,11 @@
 ThinkInk_213_Grayscale4_MFGN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
                                      EPD_SPI);
 
+// Same panel but with colstart=8: uncomment this version (and comment the one
+// above) if you see an ~8px strip on the display (e.g. the FPC-7528B revision).
+// ThinkInk_213_Grayscale4_MFGN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS,
+// EPD_BUSY, EPD_SPI, /*colstart=*/8);
+
 // 2.66" 296x152 4-gray, SSD1680 - bare display #6392 (ribbon FPC-A003)
 // ThinkInk_266_Grayscale4_MFGN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
 //                                      EPD_SPI);

--- a/src/panels/ThinkInk_213_Grayscale4_MFGN.h
+++ b/src/panels/ThinkInk_213_Grayscale4_MFGN.h
@@ -116,21 +116,30 @@ static const uint8_t ti_213mfgn_gray4_lut_code[] = {
 
 class ThinkInk_213_Grayscale4_MFGN : public Adafruit_SSD1680 {
  public:
+  // colstart: left RAM-X offset in pixels (multiple of 8). Default 0 keeps the
+  // shipped behavior; pass 8 for panels with an 8px left offset (e.g. the
+  // FPC-7528B revision of the 2.13" SSD1680 breakout).
   ThinkInk_213_Grayscale4_MFGN(int16_t SID, int16_t SCLK, int16_t DC,
                                int16_t RST, int16_t CS, int16_t SRCS,
-                               int16_t MISO, int16_t BUSY = -1)
-      : Adafruit_SSD1680(250, 122, SID, SCLK, DC, RST, CS, SRCS, MISO, BUSY){};
+                               int16_t MISO, int16_t BUSY = -1,
+                               int16_t colstart = 0)
+      : Adafruit_SSD1680(250, 122, SID, SCLK, DC, RST, CS, SRCS, MISO, BUSY),
+        _colstart(colstart){};
 
   ThinkInk_213_Grayscale4_MFGN(int16_t DC, int16_t RST, int16_t CS,
                                int16_t SRCS, int16_t BUSY = -1,
-                               SPIClass* spi = &SPI)
-      : Adafruit_SSD1680(250, 122, DC, RST, CS, SRCS, BUSY, spi){};
+                               SPIClass* spi = &SPI, int16_t colstart = 0)
+      : Adafruit_SSD1680(250, 122, DC, RST, CS, SRCS, BUSY, spi),
+        _colstart(colstart){};
 
   void begin(thinkinkmode_t mode = THINKINK_GRAYSCALE4) {
     Adafruit_SSD1680::begin(true);
 
     inkmode = mode; // Preserve ink mode for ImageReader or others
-    _xram_offset = 0;
+    // RAM-X byte offset derived from colstart (pixels). Default 0 keeps the
+    // shipped behavior; an 8px colstart (= 1 byte) removes the unwritten strip
+    // on the FPC-7528B revision of the 2.13" SSD1680 breakout.
+    _xram_offset = _colstart / 8;
 
     if (mode == THINKINK_GRAYSCALE4) {
       setColorBuffer(1, false); // layer 0 inverted
@@ -170,6 +179,10 @@ class ThinkInk_213_Grayscale4_MFGN : public Adafruit_SSD1680 {
 
     powerDown();
   }
+
+ private:
+  int16_t _colstart =
+      0; // left RAM-X offset in pixels (0 default; 8 for FPC-7528B)
 };
 
 #endif // _THINKINK_213_GRAYSCALE4_MFGN_H


### PR DESCRIPTION
Adds an optional `colstart` parameter to `ThinkInk_213_Grayscale4_MFGN` allows user settable offset for SSD1680 panels. Default colstart will be set to 0 (same as existing behavior) some panels need to use 8.

```cpp
ThinkInk_213_Grayscale4_MFGN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI, /*colstart=*/8);
```

## Tested
- Feather RP2350 
- EYESPI breakout
- [2.13" eInk breakout #4197](https://www.adafruit.com/product/4197) (FPC-7528B)


<img width="993" height="663" alt="Photo-3" src="https://github.com/user-attachments/assets/31b7de15-3e15-4408-9824-e36ced3e7c5e" />
