### PR TITLE
2.66" gray4 for ADA bare eInk #6392

### DIFF
--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -53,7 +53,7 @@
 ThinkInk_213_Grayscale4_MFGN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
                                      EPD_SPI);
 
-// 2.66" Monochrome display with 296x152 pixels and SSD1680 chipset
+// 2.66" Grayscale display with 296x152 pixels and SSD1680 chipset (#6392)
 // ThinkInk_266_Grayscale4_MFGN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
 //                                      EPD_SPI);
 


### PR DESCRIPTION
Adds a 4-gray grayscale example for the:

Adafruit [2.66" 296×152 e-ink bare display #6392](https://www.adafruit.com/product/6392) (SSD1680)

Ribbon Identifier: FPC-A003, `ThinkInk_266_Grayscale4_MFGN` class (already in library). 
No library change required.

## Tested Adafruit
- Feather RP2040 ThinkInk

<img width="1355" height="397" alt="6392-arduino-4gray-confirmed" src="https://github.com/user-attachments/assets/f00278d9-48f1-4bea-a236-1416dc05a9f2" />
