### PR TITLE
2.13" gray4 for ADA bare eInk #6383

### DIFF
--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -49,7 +49,7 @@
 // 2.13" 212x104 Grayscale display with IL0373 chipset
 // ThinkInk_213_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
-// 2.13" Grayscale Featherwing, Breakout, or bare eInk #6383 (SSD1680Z)
+// 2.13" Grayscale Featherwing #4195, Breakout #4197, or bare eInk #6383 (SSD1680Z)
 ThinkInk_213_Grayscale4_MFGN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
                                      EPD_SPI);
 

--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -49,7 +49,7 @@
 // 2.13" 212x104 Grayscale display with IL0373 chipset
 // ThinkInk_213_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
-// 2.13" Grayscale bare eInk display with 250x122 pixels and SSD1680Z chipset (#6383)
+// 2.13" Grayscale Featherwing, Breakout, or bare eInk #6383 (SSD1680Z)
 ThinkInk_213_Grayscale4_MFGN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
                                      EPD_SPI);
 

--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -49,7 +49,7 @@
 // 2.13" 212x104 Grayscale display with IL0373 chipset
 // ThinkInk_213_Grayscale4_T5 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
-// 2.13" Grayscale Featherwing or Breakout (SSD1680Z)
+// 2.13" Grayscale bare eInk display with 250x122 pixels and SSD1680Z chipset (#6383)
 ThinkInk_213_Grayscale4_MFGN display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY,
                                      EPD_SPI);
 


### PR DESCRIPTION
4-gray grayscale example for the Adafruit 2.13" 250x122 bare E-Ink Display (#[6383](https://www.adafruit.com/product/6383)).

Ribbon Identifier: FPC-7528B
Tested on Adafruit Feather RP2040 ThinkInk

<img width="1274" height="323" alt="6383-epd-framebuf-pr110" src="https://github.com/user-attachments/assets/13d48109-fb69-4f43-8127-f4cf1c1b63bf" />

