### PR TITLE
fix SSD1680 display update SPI parameter

### DIFF
--- a/src/drivers/Adafruit_SSD1680.cpp
+++ b/src/drivers/Adafruit_SSD1680.cpp
@@ -229,14 +229,10 @@ void Adafruit_SSD1680::powerUp() {
   delay(100);
   busy_wait();
 
-  const uint8_t* init_code;
+  const uint8_t* init_code = ssd1680_default_init_code;
 
   if (_epd_init_code != NULL) {
     init_code = _epd_init_code;
-  } else {
-    init_code = ssd1680_default_init_code;
-    // Default init embeds a full LUT; requires Display Mode 1.
-    _display_update_val = 0xc7;
   }
 
   EPD_commandList(init_code);


### PR DESCRIPTION
Fix SSD1680 driver for 2.9" Tricolor breakout panel by removing overwritting display update control 2 SPI command (0x22) parameter.

The issue was introduced in this commit ddf2d05cf6946a2bfa23e9c22cca2ea6c0016d44

`_display_update_val` attribute is used as the parameter for the SSD1680 "Display Update Control 2" command (0x22). Its default value is 0xF4.

`ThinkInk_290_Grayscale4_FPC7519::begin()` overrides this value for the FPC7519 grayscale panel, which is expected behavior and should only affect that specific display.

However, `Adafruit_SSD1680::powerUp()` also overwrites  `_display_update_val` with `0xC7` which causes all subsequent display update to uses this value and effectively ignore the default constructor value.

Based on the SSD1680 datasheet, the difference between `0xF4` and `0xC7` appears to be related to temperature value loading. I am not entirely sure why but restoring the default constructor value fixes tricolor operation on the tested hardware.

Note: the SSD1680 datasheet mention `0xF7`, while the library default is `0xF4`. Both value may be valid since I can't notice any difference on observed hardware and the chipset register seems to be some kind of bitmask, datasheet is a bit unclear.