### PR TITLE
ThinkInk_gray4 example: 1.54" SSD1681 entry (#4196)

### DIFF
--- a/examples/ThinkInk_gray4/ThinkInk_gray4.ino
+++ b/examples/ThinkInk_gray4/ThinkInk_gray4.ino
@@ -42,8 +42,8 @@
 // EPD_BUSY, EPD_SPI); 
 
 
-// 1.54" Grayscale Breakout (SSD1681)
-//ThinkInk_154_Grayscale4_M05 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
+// 1.54" 200x200 4-gray, SSD1681 - breakout #4196 (panel GDEY0154D67, ribbon P154030-MF1-B)
+// ThinkInk_154_Grayscale4_M05 display(EPD_DC, EPD_RESET, EPD_CS, SRAM_CS, EPD_BUSY, EPD_SPI);
 
 
 // 2.13" 212x104 Grayscale display with IL0373 chipset


### PR DESCRIPTION
Brings the 1.54" `ThinkInk_154_Grayscale4_M05` grayscale entry in the
`ThinkInk_gray4` example up to the same panel-ID comment style as the other
entries: Adafruit #4196, panel GDEY0154D67, ribbon P154030-MF1-B.

Comment-only; the class itself is already in the library. HW-verified on a
Feather RP2040 (clean 4-gray, no speckle).

<img width="583" height="610" alt="4196-arduino-infocard" src="https://github.com/user-attachments/assets/42fd0070-8960-4b06-a2ab-2136367b756c" />

