### PR TITLE
Fix delay in update for tricolor ssd1680 displays

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit EPD
-version=4.6.11
+version=4.6.12
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=ePaper display driver

--- a/src/drivers/Adafruit_SSD1680.cpp
+++ b/src/drivers/Adafruit_SSD1680.cpp
@@ -212,8 +212,10 @@ void Adafruit_SSD1680::update() {
   EPD_command(SSD1680_MASTER_ACTIVATE);
   busy_wait();
 
+  // If no busy pin is connected, wait the maximum worse case time for the
+  // update to finish before returning
   if (_busy_pin <= -1) {
-    delay(1000);
+    delay(default_refresh_delay);
   }
 }
 


### PR DESCRIPTION
**Product**: [Adafruit 2.13" HD Tri-Color eInk / ePaper Display FeatherWing - 250x122 RW Panel with SSD1680](https://www.adafruit.com/product/4814)
**Broken Example**: `Thinkink_tricolor_test.ino`

Without a BUSY pin set for the microcontroller (since this is a FeatherWing), the driver relies on a hardcoded software delay. The hardcoded delay is 1 second, but a tri-color panel expects at least ~13 seconds for a complete refresh:

To harmonize this across the library, I swapped the hardcoded delay with `default_refresh_delay` (which was already defined as `15000 ms`).

The example now works as-expected.

cc @mikeysklar 